### PR TITLE
Switch visibility support to  BOOST_SYMBOL_EXPORT. Refs #2114

### DIFF
--- a/include/boost/python/detail/config.hpp
+++ b/include/boost/python/detail/config.hpp
@@ -64,31 +64,18 @@
 #endif
 
 #if defined(BOOST_PYTHON_DYNAMIC_LIB)
-
-#  if !defined(_WIN32) && !defined(__CYGWIN__)                                  \
-    && !defined(BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY)                         \
-    && BOOST_WORKAROUND(__GNUC__, >= 3) && (__GNUC_MINOR__ >=5 || __GNUC__ > 3)
-#    define BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY 1
-#  endif 
-
-#  if BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY
+#  if defined(BOOST_SYMBOL_EXPORT)
 #     if defined(BOOST_PYTHON_SOURCE)
-#        define BOOST_PYTHON_DECL __attribute__ ((__visibility__("default")))
+#        define BOOST_PYTHON_DECL           BOOST_SYMBOL_EXPORT
+#        define BOOST_PYTHON_DECL_FORWARD   BOOST_SYMBOL_FORWARD_EXPORT
+#        define BOOST_PYTHON_DECL_EXCEPTION BOOST_EXCEPTION_EXPORT
 #        define BOOST_PYTHON_BUILD_DLL
 #     else
-#        define BOOST_PYTHON_DECL
-#     endif
-#     define BOOST_PYTHON_DECL_FORWARD
-#     define BOOST_PYTHON_DECL_EXCEPTION __attribute__ ((__visibility__("default")))
-#  elif (defined(_WIN32) || defined(__CYGWIN__))
-#     if defined(BOOST_PYTHON_SOURCE)
-#        define BOOST_PYTHON_DECL __declspec(dllexport)
-#        define BOOST_PYTHON_BUILD_DLL
-#     else
-#        define BOOST_PYTHON_DECL __declspec(dllimport)
+#        define BOOST_PYTHON_DECL           BOOST_SYMBOL_IMPORT
+#        define BOOST_PYTHON_DECL_FORWARD   BOOST_SYMBOL_FORWARD_IMPORT
+#        define BOOST_PYTHON_DECL_EXCEPTION BOOST_EXCEPTION_IMPORT
 #     endif
 #  endif
-
 #endif
 
 #ifndef BOOST_PYTHON_DECL
@@ -96,11 +83,11 @@
 #endif
 
 #ifndef BOOST_PYTHON_DECL_FORWARD
-#  define BOOST_PYTHON_DECL_FORWARD BOOST_PYTHON_DECL
+#  define BOOST_PYTHON_DECL_FORWARD
 #endif
 
 #ifndef BOOST_PYTHON_DECL_EXCEPTION
-#  define BOOST_PYTHON_DECL_EXCEPTION BOOST_PYTHON_DECL
+#  define BOOST_PYTHON_DECL_EXCEPTION
 #endif
 
 #if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))

--- a/include/boost/python/detail/exception_handler.hpp
+++ b/include/boost/python/detail/exception_handler.hpp
@@ -11,7 +11,7 @@
 
 namespace boost { namespace python { namespace detail {
 
-struct BOOST_PYTHON_DECL_FORWARD exception_handler;
+struct exception_handler;
 
 typedef function2<bool, exception_handler const&, function0<void> const&> handler_function;
 

--- a/include/boost/python/detail/wrapper_base.hpp
+++ b/include/boost/python/detail/wrapper_base.hpp
@@ -14,7 +14,7 @@ class override;
 
 namespace detail
 {
-  class BOOST_PYTHON_DECL_FORWARD wrapper_base;
+  class wrapper_base;
   
   namespace wrapper_base_ // ADL disabler
   {

--- a/include/boost/python/errors.hpp
+++ b/include/boost/python/errors.hpp
@@ -14,7 +14,7 @@
 
 namespace boost { namespace python {
 
-struct BOOST_PYTHON_DECL_EXCEPTION error_already_set
+struct BOOST_PYTHON_DECL error_already_set
 {
   virtual ~error_already_set();
 };

--- a/include/boost/python/object/instance.hpp
+++ b/include/boost/python/object/instance.hpp
@@ -11,7 +11,7 @@
 
 namespace boost { namespace python
 {
-  struct BOOST_PYTHON_DECL_FORWARD instance_holder;
+  struct instance_holder;
 }} // namespace boost::python
 
 namespace boost { namespace python { namespace objects { 


### PR DESCRIPTION
Found while cleaning up my git svn mirror after the conversion. The patch switches Boost.Python to the common BOOST_SYMBOL_\*  macros from Boost.Config. This includes some minor cleanups for gcc which does not like visibility attributes on forward declarations. Testest with gcc and msvc-9.0
