### PR TITLE
[doc] indexing_suite and related classes are in boost/python/suite/indexing/

### DIFF
--- a/doc/v2/indexing.html
+++ b/doc/v2/indexing.html
@@ -28,8 +28,8 @@
             <a href="../index.html">Boost.Python</a>
           </h1>
           
-      <h2> Headers &lt;boost/python/indexing/indexing_suite.hpp&gt;<br>
-        &lt;boost/python/indexing/vector_indexing_suite.hpp&gt;</h2>
+      <h2> Headers &lt;boost/python/suite/indexing/indexing_suite.hpp&gt;<br>
+        &lt;boost/python/suite/indexing/vector_indexing_suite.hpp&gt;</h2>
         </td>
       </tr>
     </table>
@@ -141,7 +141,7 @@
     <hr>
     
 <h2> <a name="interface"></a>The Boost.Python Indexing Interface</h2>
-<h3> <a name="indexing_suite"></a>indexing_suite [ Header &lt;boost/python/indexing/indexing_suite.hpp&gt; 
+<h3> <a name="indexing_suite"></a>indexing_suite [ Header &lt;boost/python/suite/indexing/indexing_suite.hpp&gt; 
   ]</h3>
     <p>
       The <tt>indexing_suite</tt> class is the base  class for the
@@ -272,7 +272,7 @@
       some cases, we can refine the predefined suites to suit our needs.
     </p>
     
-<h3> <a name="vector_indexing_suite"></a>vector_indexing_suite [ Header &lt;boost/python/indexing/vector_indexing_suite.hpp&gt; 
+<h3> <a name="vector_indexing_suite"></a>vector_indexing_suite [ Header &lt;boost/python/suite/indexing/vector_indexing_suite.hpp&gt; 
   ] </h3>
 <p>
       The <tt>vector_indexing_suite</tt> class is a predefined
@@ -298,7 +298,7 @@
          along with its <a href="../../test/vector_indexing_suite.py">python
          test</a>).
 </p>
-    <h3><a name="map_indexing_suite" id="map_indexing_suite"></a>map_indexing_suite [ Header &lt;boost/python/indexing/map_indexing_suite.hpp&gt; ] </h3>
+    <h3><a name="map_indexing_suite" id="map_indexing_suite"></a>map_indexing_suite [ Header &lt;boost/python/suite/indexing/map_indexing_suite.hpp&gt; ] </h3>
     <p> The <tt>map_indexing_suite</tt> class is a predefined <tt>indexing_suite</tt> derived class designed to wrap <tt>std::map</tt> (and <tt>std::map</tt> like [i.e. a class with std::map interface]) classes. It provides all the policies required by the <tt>indexing_suite</tt>. </p>
     <p> Example usage: </p>
     <pre>


### PR DESCRIPTION
Fix indexing.html to mention correct header paths.