### PR TITLE
Fix compile-time error

### DIFF
--- a/include/boost/python/type_id.hpp
+++ b/include/boost/python/type_id.hpp
@@ -15,7 +15,6 @@
 # include <boost/static_assert.hpp>
 # include <boost/detail/workaround.hpp>
 # include <boost/type_traits/same_traits.hpp>
-# include <boost/type_traits/broken_compiler_spec.hpp>
 
 #  ifndef BOOST_PYTHON_HAVE_GCC_CP_DEMANGLE
 #   if defined(__GNUC__)                                                \


### PR DESCRIPTION
This fixes an error caused by boostorg/type_traits@d5c5988d92871f5474646dc4e9a6cb9d6809f460, where the broken_compiler_spec header was removed. It doesn't seem to actually be used, so I just removed that line.
