### PR TITLE
Only use 'pragma once' when supported.

### DIFF
--- a/include/boost/python/other.hpp
+++ b/include/boost/python/other.hpp
@@ -7,9 +7,10 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-# pragma once
-
 # include <boost/config.hpp>
+# if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+# endif
 
 namespace boost { namespace python {
 

--- a/include/boost/python/ptr.hpp
+++ b/include/boost/python/ptr.hpp
@@ -11,9 +11,11 @@
 //  Copyright (C) 1999, 2000 Jaakko Jarvi (jaakko.jarvi@cs.utu.fi)
 //  Copyright (C) 2001 Peter Dimov
 
-# pragma once
-
 # include <boost/config.hpp>
+# if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+# endif
+
 # include <boost/mpl/bool.hpp>
 
 namespace boost { namespace python {


### PR DESCRIPTION
The checks were removed in 42e7d7bbb3c2b0994169b2d02b9e6767db90b08a. This is a little better as most compilers support it nowadays.
