### PR TITLE
Boost.Build now uses src/ instead of v2/

### DIFF
--- a/example/boost-build.jam
+++ b/example/boost-build.jam
@@ -2,6 +2,6 @@
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# Edit this path to point at the tools/build/v2 subdirectory of your
+# Edit this path to point at the tools/build/src subdirectory of your
 # Boost installation.  Absolute paths work, too.
-boost-build ../../../tools/build/v2 ;
+boost-build ../../../tools/build/src ;

--- a/example/quickstart/boost-build.jam
+++ b/example/quickstart/boost-build.jam
@@ -2,6 +2,6 @@
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# Edit this path to point at the tools/build/v2 subdirectory of your
+# Edit this path to point at the tools/build/src subdirectory of your
 # Boost installation.  Absolute paths work, too.
-boost-build ../../../../tools/build/v2 ;
+boost-build ../../../../tools/build/src ;


### PR DESCRIPTION
Update examples to reflect this