### PR TITLE
added 'construct_custodian_for' and test

### DIFF
--- a/include/boost/python/init.hpp
+++ b/include/boost/python/init.hpp
@@ -266,6 +266,15 @@ class init : public init_base<init<BOOST_PYTHON_OVERLOAD_ARGS> >
             policies, this->doc_string(), this->keywords());
     }
 
+    template <std::size_t ward>
+    init_with_call_policies<with_custodian_and_ward_postcall<1, ward+1>, self_t>
+    operator[](construct_custodian_for<ward> const&) const
+    {
+        typedef with_custodian_and_ward_postcall<1, ward+1> init_policy;
+        return init_with_call_policies<init_policy, self_t>(
+                   init_policy(), this->doc_string(), this->keywords());
+    }
+
     typedef detail::type_list<BOOST_PYTHON_OVERLOAD_ARGS> signature_;
 
     typedef detail::is_optional<

--- a/include/boost/python/with_custodian_and_ward.hpp
+++ b/include/boost/python/with_custodian_and_ward.hpp
@@ -119,6 +119,49 @@ struct with_custodian_and_ward_postcall : BasePolicy_
     }
 };
 
+template <std::size_t ward>
+struct construct_custodian_for : default_call_policies
+{
+    BOOST_STATIC_ASSERT(ward > 0);
+    
+    template <class ArgumentPackage>
+    static PyObject* postcall(ArgumentPackage const& args_, PyObject* result)
+    {
+        std::size_t arity_ = detail::arity(args_);
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1300)
+        if (ward > arity_ )
+#else
+        // check if ward exceeds the arity
+        // (this weird formulation avoids "always false" warnings
+        // for arity_ = 0)
+        if ( (std::max<std::size_t>)(0, ward) > arity_ )
+#endif
+        {
+            PyErr_SetString(
+                PyExc_IndexError
+              , "boost::python::construct_custodian_for: argument index out of range"
+            );
+            return 0;
+        }
+        
+        PyObject* patient = detail::get_prev<ward>::execute(args_, result);
+        PyObject* nurse = detail::get_prev<1>::execute(args_.base);
+
+        if (nurse == 0) return 0;
+    
+        result = default_call_policies::postcall(args_, result);
+        if (result == 0)
+            return 0;
+            
+        if (python::objects::make_nurse_and_patient(nurse, patient) == 0)
+        {
+            Py_XDECREF(result);
+            return 0;
+        }
+        return result;
+    }
+};
+
 
 }} // namespace boost::python
 

--- a/test/test_pointer_adoption.py
+++ b/test/test_pointer_adoption.py
@@ -3,6 +3,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 """
 >>> from test_pointer_adoption_ext import *
+>>> import sys
 
 >>> num_a_instances()
 0
@@ -10,7 +11,8 @@
 >>> a = create('dynamically allocated')
 >>> num_a_instances()
 1
-
+>>> sys.getrefcount(a)
+2
 >>> a.content()
 'dynamically allocated'
 
@@ -55,13 +57,71 @@
 Test call policies for constructors here
 
 >>> a = create('second a')
+>>> a.content()
+'second a'
 >>> num_a_instances()
 1
+>>> b = a.create_B()
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+3
+>>> b.a_content()
+'second a'
+>>> b = None
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+2
+
 >>> b = B(a)
 >>> num_a_instances()
 1
+>>> sys.getrefcount(a)
+3
 >>> a.content()
 'second a'
+>>> b.a_content()
+'second a'
+>>> b = None
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+2
+
+>>> b = B1(a)
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+3
+>>> a.content()
+'second a'
+>>> b.a_content()
+'second a'
+>>> b = None
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+2
+
+>>> b = B2(a)
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+3
+>>> a.content()
+'second a'
+>>> b.a_content()
+'second a'
+>>> b = None
+>>> num_a_instances()
+1
+>>> sys.getrefcount(a)
+2
+
+>>> b = B(a)
+>>> num_a_instances()
+1
 
 >>> del a
 >>> num_a_instances()


### PR DESCRIPTION
(note: I will update the documentation as well when this pull request gets accepted)

This pull request proposes a fix for the long-standing problem that `with_custodian_and_ward_postcall` doesn't work in connection with `make_constructor` (see e.g. https://mail.python.org/pipermail/cplusplus-sig/2007-June/012145.html).

Consider the following class definitions:

``` c++
struct A {
    int i_;

    A(int i)
    : i_(i)
    {}
};

struct B {
    A * a_;

    B(A * a)
    : a_(a)
    {}

    int a_content() 
    {
        return a_ == 0 ? 0 : a_->i_;
    }
};

B * create_B(A * a)
{
    return new B(a);
}    
```

and the corresponding boost::python glue code

``` c++
BOOST_PYTHON_MODULE(test_custodian_and_ward)
{
    class_<A>("A", no_init)
        .def(init<int>())
        // #1
        .def("create_B", &create_B, with_custodian_and_ward_postcall<0,1,
                                    return_value_policy<manage_new_object> >())
        ;

    class_<B>("B1", no_init)
        // #2
        .def(init<A*>()[with_custodian_and_ward_postcall<1,2>()])
        .def("a_content", &B::a_content)
        ;

    class_<B>("B2", no_init)
        // #3
        .def("__init__", make_constructor(&create_B, with_custodian_and_ward_postcall<1,2>()))
        .def("a_content", &B::a_content)
        ;

    class_<B>("B3", no_init)
        // #4
        .def("__init__", make_constructor(&create_B, with_custodian_and_ward_postcall<0,1>()))
        .def("a_content", &B::a_content)
        ;
}
```

In this code
- `#1` works as desired
- `#2` works, but is a bit counter-intuitive because indexing suddenly starts at 1
- `#3` causes an "argument index out of range" error
- `#4` runs, but fails to establish the desired custodian-and-ward relationship (i.e. `B3.a_content()` may crash because the containd `A` instance can be deleted prematurely)

The pull request introduces a new policy `construct_custodian_for` which solves problems `#2-4`. It is used like this:

``` c++
BOOST_PYTHON_MODULE(test_custodian_and_ward)
{
    ...

    class_<B>("B1", no_init)
        .def(init<A*>()[construct_custodian_for<1>()])
        .def("a_content", &B::a_content)
        ;

    class_<B>("B2", no_init)
        .def("__init__", make_constructor(&create_B, construct_custodian_for<1>()))
        .def("a_content", &B::a_content)
        ;
}
```
