### PR TITLE
override: check for NULL when calling overrides

### DIFF
--- a/include/boost/python/override.hpp
+++ b/include/boost/python/override.hpp
@@ -131,13 +131,17 @@ template <
 detail::method_result
 operator()( BOOST_PP_ENUM_BINARY_PARAMS_Z(1, N, A, const& a) ) const
 {
-    detail::method_result x(
-        PyEval_CallFunction(
-            this->ptr()
-          , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
-            BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_fast_arg_to_python_get, nil)
-        ));
-    return x;
+    PyObject* const result = PyEval_CallFunction(
+                                this->ptr()
+                                , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
+                                  BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_fast_arg_to_python_get, nil)
+                             );
+
+    if (!result) {
+        throw_error_already_set();
+    }
+
+    return detail::method_result(result);
 }
 
 # undef N


### PR DESCRIPTION
PyEval_CallFunction can return NULL in the event of an error which
causes method_result to error out. Instead, check for NULL and throw an
exception since Python has already set it.