### PR TITLE
Hold the GIL while releasing shared_ptr_deleter's python handle.

### DIFF
--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -30,8 +30,30 @@ shared_ptr_deleter::shared_ptr_deleter(handle<> owner)
 
 shared_ptr_deleter::~shared_ptr_deleter() {}
 
+namespace
+{
+
+  class scoped_gil_state
+  {
+   public:
+      scoped_gil_state()
+          : m_gil_state(PyGILState_Ensure())
+      {}
+
+      ~scoped_gil_state()
+      {
+          PyGILState_Release(m_gil_state);
+      }
+
+   private:
+      PyGILState_STATE m_gil_state;
+  };
+
+}
+
 void shared_ptr_deleter::operator()(void const*)
 {
+    scoped_gil_state gil;
     owner.reset();
 }
 


### PR DESCRIPTION
Python requires that the GIL be held while releasing objects, but requiring
that all clients of boost::shared_ptr-held types do so explicitly is
error-prone.  In the case where the wrapped type is consumed in a library that
you don't control, it might not even be possible to do correctly.  Instead,
have shared_ptr_deleter acquire the GIL on client's behalf at exactly the time
when it is necessary.

There's already an open trac issue for this (https://svn.boost.org/trac/boost/ticket/8290)
but the documentation for handle::release doesn't specify that it never throws, so the
patch in trac would fail to properly release the GIL state in that circumstance.
