### PR TITLE
Fix is_volatile constant in detail::cv_tag<>

### DIFF
--- a/include/boost/python/detail/cv_category.hpp
+++ b/include/boost/python/detail/cv_category.hpp
@@ -12,7 +12,7 @@ template <bool is_const_, bool is_volatile_>
 struct cv_tag
 {
     BOOST_STATIC_CONSTANT(bool, is_const = is_const_);
-    BOOST_STATIC_CONSTANT(bool, is_volatile = is_const_);
+    BOOST_STATIC_CONSTANT(bool, is_volatile = is_volatile_);
 };
 
 typedef cv_tag<false,false> cv_unqualified;


### PR DESCRIPTION
This is the fix for https://svn.boost.org/trac/boost/ticket/10846.