### PR TITLE
Fix Trac #10932 Missing Include: Bind Placeholders

### DIFF
--- a/include/boost/python/exception_translator.hpp
+++ b/include/boost/python/exception_translator.hpp
@@ -8,6 +8,7 @@
 # include <boost/python/detail/prefix.hpp>
 
 # include <boost/bind.hpp>
+# include <boost/bind/placeholders.hpp>
 # include <boost/type.hpp>
 # include <boost/python/detail/translate_exception.hpp>
 # include <boost/python/detail/exception_handler.hpp>


### PR DESCRIPTION
This is a pull request for trac issue https://svn.boost.org/trac/boost/ticket/10932

I am compiling Boost.Python with `nvcc/6.5`, `gcc/4.6.2`, `python/2.7.8` and `cmake/3.0.1` right now.

As a side note, I modified the standard `FindPythonLibs.cmake` a bit to match the cuda_add_library calls.

During compile, get an error
```
boost/python/exception_translator.hpp(22): error: identifier "_1" is undefined
boost/python/exception_translator.hpp(22): error: identifier "_2" is undefined
```

due to a missing include:
```
#include <boost/bind/placeholders.hpp>
```