### PR TITLE
Fix #11100 and #8058: binary compatibility and leaked file handle in exec_file()

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -84,18 +84,18 @@ object BOOST_PYTHON_DECL exec_file(str filename, object global, object local)
   if (local.is_none()) local = global;
   // should be 'char const *' but older python versions don't use 'const' yet.
   char *f = python::extract<char *>(filename);
-#if PY_VERSION_HEX >= 0x03000000
-  // TODO(bhy) temporary workaround for Python 3.
-  // should figure out a way to avoid binary incompatibilities as the Python 2
-  // version did.
-  FILE *fs = fopen(f, "r");
-#else
+
   // Let python open the file to avoid potential binary incompatibilities.
+#if PY_VERSION_HEX >= 0x03000000
+  // See http://www.codeproject.com/Articles/820116/Embedding-Python-program-in-a-C-Cplusplus-code
+  FILE *fs = _Py_fopen(f, "r");
+#else
   PyObject *pyfile = PyFile_FromString(f, const_cast<char*>("r"));
   if (!pyfile) throw std::invalid_argument(std::string(f) + " : no such file");
   python::handle<> file(pyfile);
   FILE *fs = PyFile_AsFile(file.get());
 #endif
+
   PyObject* result = PyRun_File(fs,
                 f,
                 Py_file_input,

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -96,10 +96,12 @@ object BOOST_PYTHON_DECL exec_file(str filename, object global, object local)
   FILE *fs = PyFile_AsFile(file.get());
 #endif
 
-  PyObject* result = PyRun_File(fs,
+  int closeit = 1;  // Close file before PyRun returns
+  PyObject* result = PyRun_FileEx(fs,
                 f,
                 Py_file_input,
-                global.ptr(), local.ptr());
+                global.ptr(), local.ptr(),
+                closeit);
   if (!result) throw_error_already_set();
   return object(detail::new_reference(result));
 }


### PR DESCRIPTION
Fixes the following bugs:
https://svn.boost.org/trac/boost/ticket/11100
https://svn.boost.org/trac/boost/ticket/8058