### PR TITLE
Fixes empty example

### DIFF
--- a/example/quickstart/Jamroot
+++ b/example/quickstart/Jamroot
@@ -31,7 +31,7 @@ import testing ;
 testing.make-test run-pyd : extending test_extending.py : : test_ext ;
 
 # Declare a test of the embedding application
-testing.run embedding 
+testing.run embedding embedding.cpp
   :              # any ordinary arguments
   : script.py    # any arguments that should be treated as relative paths
   :              # requirements


### PR DESCRIPTION
Uses of visual studio were getting a 'unresolved external symbol _mainCRTStartup' because there was no main() being linked into the test_embed.exe. I'm not a bjam expert, but I think that is because the embedding target is an executable (instead of an obj/lib?). I also have no idea if this was a problem on unix or if this fix will affect that platform.