### PR TITLE
GCC warns about unused local typedef

### DIFF
--- a/include/boost/python/args_fwd.hpp
+++ b/include/boost/python/args_fwd.hpp
@@ -36,15 +36,6 @@ namespace detail
       BOOST_STATIC_CONSTANT(std::size_t, size = 0);
       static keyword_range range() { return keyword_range(); }
   };
-
-  namespace error
-  {
-    template <int keywords, int function_args>
-    struct more_keywords_than_function_arguments
-    {
-        typedef char too_many_keywords[keywords > function_args ? -1 : 1];
-    };
-  }
 }
 
 }} // namespace boost::python

--- a/include/boost/python/cast.hpp
+++ b/include/boost/python/cast.hpp
@@ -12,6 +12,7 @@
 # include <boost/type.hpp>
 # include <boost/python/base_type_traits.hpp>
 # include <boost/python/detail/convertible.hpp>
+# include <boost/static_assert.hpp>
 
 namespace boost { namespace python { 
 
@@ -70,7 +71,8 @@ namespace detail
   template <class T>
   inline void assert_castable(boost::type<T>* = 0)
   {
-      typedef char must_be_a_complete_type[sizeof(T)];
+      // T must be a complete type.
+      BOOST_STATIC_ASSERT(sizeof(T) == sizeof(T));
   }
 
   template <class Source, class Target>

--- a/include/boost/python/class.hpp
+++ b/include/boost/python/class.hpp
@@ -39,6 +39,7 @@
 # include <boost/mpl/for_each.hpp>
 # include <boost/mpl/bool.hpp>
 # include <boost/mpl/not.hpp>
+# include <boost/mpl/assert.hpp>
 
 # include <boost/detail/workaround.hpp>
 
@@ -107,23 +108,6 @@ namespace detail
   namespace error
   {
     //
-    // A meta-assertion mechanism which prints nice error messages and
-    // backtraces on lots of compilers. Usage:
-    //
-    //      assertion<C>::failed
-    //
-    // where C is an MPL metafunction class
-    //
-    
-    template <class C> struct assertion_failed { };
-    template <class C> struct assertion_ok { typedef C failed; };
-
-    template <class C>
-    struct assertion
-        : mpl::if_<C, assertion_ok<C>, assertion_failed<C> >::type
-    {};
-
-    //
     // Checks for validity of arguments used to define virtual
     // functions with default implementations.
     //
@@ -141,9 +125,11 @@ namespace detail
             // https://svn.boost.org/trac/boost/ticket/5803
             //typedef typename assertion<mpl::not_<is_same<Default,Fn> > >::failed test0;
 # if !BOOST_WORKAROUND(__MWERKS__, <= 0x2407)
-            typedef typename assertion<is_polymorphic<T> >::failed test1;
-# endif 
-            typedef typename assertion<is_member_function_pointer<Fn> >::failed test2;
+            BOOST_MPL_ASSERT_MSG(is_polymorphic<T>::value,
+                                 NOT_POLYMORPHIC, (T));
+# endif
+            BOOST_MPL_ASSERT_MSG(is_member_function_pointer<Fn>::value,
+                                 NOT_MEMBER_FUNCTION_POINTER, (Fn));
             not_a_derived_class_member<Default>(Fn());
         }
     };

--- a/include/boost/python/def.hpp
+++ b/include/boost/python/def.hpp
@@ -15,6 +15,8 @@
 # include <boost/python/signature.hpp>
 # include <boost/python/detail/scope.hpp>
 
+# include <boost/mpl/assert.hpp>
+
 namespace boost { namespace python {
 
 namespace detail
@@ -35,9 +37,8 @@ namespace detail
       char const* name, F const& fn, Helper const& helper)
   {
       // Must not try to use default implementations except with method definitions.
-      typedef typename error::multiple_functions_passed_to_def<
-          Helper::has_default_implementation
-          >::type assertion;
+      BOOST_MPL_ASSERT_MSG(!Helper::has_default_implementation,
+                           MULTIPLE_FUNCTIONS_PASSED_TO_DEF, (Helper));
       
       detail::scope_setattr_doc(
           name, boost::python::make_function(

--- a/include/boost/python/detail/defaults_gen.hpp
+++ b/include/boost/python/detail/defaults_gen.hpp
@@ -26,6 +26,7 @@
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/next.hpp>
 #include <boost/mpl/deref.hpp>
+#include <boost/mpl/assert.hpp>
 #include <cstddef>
 
 namespace boost { namespace python {
@@ -211,18 +212,16 @@ namespace detail
         : ::boost::python::detail::overloads_common<fstubs_name>(                           \
             doc, keywords.range())                                                          \
     {                                                                                       \
-        typedef typename ::boost::python::detail::                                          \
-            error::more_keywords_than_function_arguments<                                   \
-                N,n_args>::too_many_keywords assertion;                                     \
+        BOOST_MPL_ASSERT_MSG(N <= n_args,                                                   \
+                             MORE_KEYWORDS_THAN_FUNCTION_ARGUMENTS, ());                    \
     }                                                                                       \
     template <std::size_t N>                                                                \
     fstubs_name(::boost::python::detail::keywords<N> const& keywords, char const* doc = 0)  \
         : ::boost::python::detail::overloads_common<fstubs_name>(                           \
             doc, keywords.range())                                                          \
     {                                                                                       \
-        typedef typename ::boost::python::detail::                                          \
-            error::more_keywords_than_function_arguments<                                   \
-                N,n_args>::too_many_keywords assertion;                                     \
+        BOOST_MPL_ASSERT_MSG(N <= n_args,                                                   \
+                             MORE_KEYWORDS_THAN_FUNCTION_ARGUMENTS, ());                    \
     }
 
 # if defined(BOOST_NO_VOID_RETURNS)

--- a/include/boost/python/init.hpp
+++ b/include/boost/python/init.hpp
@@ -26,7 +26,7 @@
 #include <boost/mpl/prior.hpp>
 #include <boost/mpl/joint_view.hpp>
 #include <boost/mpl/back.hpp>
-
+#include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #include <boost/preprocessor/enum_params_with_a_default.hpp>
@@ -63,15 +63,6 @@ struct optional; // forward declaration
 
 namespace detail
 {
-  namespace error
-  {
-    template <int keywords, int init_args>
-    struct more_keywords_than_init_arguments
-    {
-        typedef char too_many_keywords[init_args - keywords >= 0 ? 1 : -1];
-    };
-  }
-
   //  is_optional<T>::value
   //
   //      This metaprogram checks if T is an optional
@@ -244,18 +235,16 @@ class init : public init_base<init<BOOST_PYTHON_OVERLOAD_ARGS> >
     init(char const* doc_, detail::keywords<N> const& kw)
         : base(doc_, kw.range())
     {
-        typedef typename detail::error::more_keywords_than_init_arguments<
-            N, n_arguments::value + 1
-            >::too_many_keywords assertion;
+        BOOST_MPL_ASSERT_MSG(N <= n_arguments::value + 1,
+                             MORE_KEYWORDS_THAN_FUNCTION_ARGUMENTS, ());
     }
 
     template <std::size_t N>
     init(detail::keywords<N> const& kw, char const* doc_ = 0)
         : base(doc_, kw.range())
     {
-        typedef typename detail::error::more_keywords_than_init_arguments<
-            N, n_arguments::value + 1
-            >::too_many_keywords assertion;
+      BOOST_MPL_ASSERT_MSG(N <= n_arguments::value + 1,
+                             MORE_KEYWORDS_THAN_FUNCTION_ARGUMENTS, ());
     }
 
     template <class CallPoliciesT>

--- a/include/boost/python/make_constructor.hpp
+++ b/include/boost/python/make_constructor.hpp
@@ -181,10 +181,9 @@ namespace detail
   {
       enum { arity = mpl::size<Sig>::value - 1 };
       
-      typedef typename detail::error::more_keywords_than_function_arguments<
-          NumKeywords::value, arity
-          >::too_many_keywords assertion;
     
+      BOOST_MPL_ASSERT_MSG(NumKeywords::value <= arity,
+                           MORE_KEYWORDS_THAN_FUNCTION_ARGUMENTS, ());
       typedef typename outer_constructor_signature<Sig>::type outer_signature;
 
       typedef constructor_policy<CallPolicies> inner_policy;

--- a/include/boost/python/object/pickle_support.hpp
+++ b/include/boost/python/object/pickle_support.hpp
@@ -6,6 +6,7 @@
 # define BOOST_PYTHON_OBJECT_PICKLE_SUPPORT_RWGK20020603_HPP
 
 # include <boost/python/detail/prefix.hpp>
+# include <boost/mpl/assert.hpp>
 
 namespace boost { namespace python {
 
@@ -21,10 +22,6 @@ BOOST_PYTHON_DECL object const& make_instance_reduce_function();
 struct pickle_suite;
 
 namespace error_messages {
-
-  template <class T>
-  struct missing_pickle_suite_function_or_incorrect_signature {};
-
   inline void must_be_derived_from_pickle_suite(pickle_suite const&) {}
 }
 
@@ -105,9 +102,8 @@ namespace detail {
       Class_&,
       ...)
     {
-      typedef typename
-        error_messages::missing_pickle_suite_function_or_incorrect_signature<
-          Class_>::error_type error_type;
+      BOOST_MPL_ASSERT_MSG
+        (false, MISSING_PICKLE_SUITE_FUNCTION_OR_INCORRECT_SIGNATURE, ());
     }
   };
 

--- a/include/boost/python/to_python_value.hpp
+++ b/include/boost/python/to_python_value.hpp
@@ -147,11 +147,6 @@ namespace detail
   template <class T>
   inline PyObject* registry_to_python_value<T>::operator()(argument_type x) const
   {
-      typedef converter::registered<argument_type> r;
-# if BOOST_WORKAROUND(__GNUC__, < 3)
-      // suppresses an ICE, somehow
-      (void)r::converters;
-# endif 
       return converter::registered<argument_type>::converters.to_python(&x);
   }
 


### PR DESCRIPTION
I only apply those patchs: https://svn.boost.org/trac/boost/ticket/8888

I don't own those patchs but I need them.