### PR TITLE
Use _Py_fopen instead of fopen

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -85,7 +85,7 @@ object BOOST_PYTHON_DECL exec_file(str filename, object global, object local)
   // should be 'char const *' but older python versions don't use 'const' yet.
   char *f = python::extract<char *>(filename);
 #if PY_VERSION_HEX >= 0x03040000
-  FILE *fs = fopen(f, "r");
+  FILE *fs = _Py_fopen(f, "r");
 #elif PY_VERSION_HEX >= 0x03000000
   PyObject *fo = Py_BuildValue("s", f);
   FILE *fs = _Py_fopen(fo, "r");


### PR DESCRIPTION
A followup fix for the previous commit 36f8f6941134583cef0fa48701a1989f2f49d4ec.