### PR TITLE
Remove unused deprecated header file

### DIFF
--- a/include/boost/python/detail/def_helper.hpp
+++ b/include/boost/python/detail/def_helper.hpp
@@ -6,7 +6,6 @@
 # define DEF_HELPER_DWA200287_HPP
 
 # include <boost/python/args.hpp>
-# include <boost/type_traits/ice.hpp>
 # include <boost/type_traits/same_traits.hpp>
 # include <boost/python/detail/indirect_traits.hpp>
 # include <boost/mpl/not.hpp>


### PR DESCRIPTION
The deprecated header is on type traits 'develop' branch.