### PR TITLE
Don't assume SIZEOF_LONG is undefined on cygwin

### DIFF
--- a/include/boost/python/detail/wrap_python.hpp
+++ b/include/boost/python/detail/wrap_python.hpp
@@ -85,7 +85,9 @@
 #if defined(_WIN32) || defined(__CYGWIN__)
 # if defined(__GNUC__) && defined(__CYGWIN__)
 
-#  define SIZEOF_LONG 4
+#  ifndef SIZEOF_LONG
+#   define SIZEOF_LONG 4
+#  endif
 
 #  if PY_MAJOR_VERSION < 2 || PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION <= 2
 


### PR DESCRIPTION
SIZEOF_LONG is defined in pyconfig.h for python 2.7 in my version of cygwin.  More importantly it's defined as 8, so I was getting errors like:

```
In file included from /usr/include/python2.7/Python.h:58:0,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/detail/wrap_python.hpp:144,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/detail/prefix.hpp:13,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/handle.hpp:8,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/boost/python/converter/arg_to_python_base.hpp:7,
                 from /cygdrive/c/Users/davidm/.vim/bundle/YouCompleteMe/third_party/ycmd/cpp/BoostParts/libs/python/src/converter/arg_to_python_base.cpp:6:
/usr/include/python2.7/pyport.h:886:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
 #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  ^
```