### PR TITLE
Unset 'boost.defaults' set in Jamroot.

### DIFF
--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -9,7 +9,9 @@ path-constant images : html/images ;
 
 
 project python/doc
-    : requirements <format>html:<xsl:param>boost.defaults=none
+    : requirements
+      -<xsl:param>boost.defaults=Boost
+      <format>html:<xsl:param>boost.defaults=none
       <format>html:<xsl:param>toc.max.depth=3
       <format>html:<xsl:param>toc.section.depth=2
       <format>html:<xsl:param>chunk.section.depth=1


### PR DESCRIPTION
Not using '<format>html' as it seems it has to match the original
setting exactly.