### PR TITLE
fix a static initialization fiasco with ios_base

### DIFF
--- a/include/boost/python/converter/registered.hpp
+++ b/include/boost/python/converter/registered.hpp
@@ -14,6 +14,11 @@
 # include <boost/python/type_id.hpp>
 # include <boost/type.hpp>
 
+#if defined(BOOST_PYTHON_TRACE_REGISTRY) \
+ || defined(BOOST_PYTHON_CONVERTER_REGISTRY_APPLE_MACH_WORKAROUND)
+# include <iostream>
+#endif
+
 namespace boost {
 
 // You'll see shared_ptr mentioned in this header because we need to


### PR DESCRIPTION
see http://stackoverflow.com/questions/12318693/c-segmentation-fault-
when-using-cout-in-static-variable-initialization for a reference of
what was happening when iostreams were used within boost.python
registry's global static ctors.