### PR TITLE
Add cygwin64 support to wrap_python.hpp

### DIFF
--- a/include/boost/python/detail/wrap_python.hpp
+++ b/include/boost/python/detail/wrap_python.hpp
@@ -85,13 +85,22 @@
 #if defined(_WIN32) || defined(__CYGWIN__)
 # if defined(__GNUC__) && defined(__CYGWIN__)
 
-#  define SIZEOF_LONG 4
+#  if defined(__LP64__)
+#   define SIZEOF_LONG 8
+#  else
+#   define SIZEOF_LONG 4
+#  endif
+
 
 #  if PY_MAJOR_VERSION < 2 || PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION <= 2
 
 typedef int pid_t;
 
-#   define WORD_BIT 32
+#   if defined(__LP64__)
+#    define WORD_BIT 64
+#   else
+#    define WORD_BIT 32
+#   endif
 #   define hypot _hypot
 #   include <stdio.h>
 


### PR DESCRIPTION
This patch adds 64 bit support. 

Currently the lack of 64 bit support for Cygwin prevents projects from compiling on Cygwin64 (see Valloric/YouCompleteMe#684). Variations of this fix has been circulating for [a few years](https://github.com/Valloric/YouCompleteMe/issues/66#issuecomment-27879120).

Originally submitted [on the old Trac issue tracker 9 months ago](https://svn.boost.org/trac/boost/ticket/11125).