### PR TITLE
Close the file handle used in exec_file() (for #52)

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -101,6 +101,9 @@ object BOOST_PYTHON_DECL exec_file(str filename, object global, object local)
                 f,
                 Py_file_input,
 		global.ptr(), local.ptr());
+#if PY_VERSION_HEX >= 0x03000000
+  fclose(fs);
+#endif
   if (!result) throw_error_already_set();
   return object(detail::new_reference(result));
 }


### PR DESCRIPTION
For python >= 3, a plain `FILE*` is used, whereas for python2, an object handle takes care of the file object lifetime.
This commit manually closes the file handle after the `PyRun_File()` call.