### PR TITLE
Improve initialization scalability

### DIFF
--- a/src/object/inheritance.cpp
+++ b/src/object/inheritance.cpp
@@ -69,7 +69,8 @@ namespace
   
                  // The function which casts a void* from the edge's source type
                  // to its destination type.
-                 , property<edge_cast_t,cast_function> > >
+                 , property<edge_cast_t,cast_function> >
+      , no_property, vecS >
 #if 0
   {};
 #else


### PR DESCRIPTION
I've run into a situation where the time spent initializing Boost Python inheritance structures is having a significant impact on application startup times.  The application in question winds up making thousands of registrations, across dozens of libraries. Profiling turned up a couple of hot spots: re-initializing the `smart_graph` structures multiple times and `num_edges` running in linear time for some versions of libstdc++.
