### PR TITLE
Assert refcount before decrement

### DIFF
--- a/include/boost/python/object_core.hpp
+++ b/include/boost/python/object_core.hpp
@@ -422,6 +422,7 @@ inline api::object_base& api::object_base::operator=(api::object_base const& rhs
 
 inline api::object_base::~object_base()
 {
+    assert( Py_REFCNT(m_ptr) > 0 );
     Py_DECREF(m_ptr);
 }
 

--- a/include/boost/python/refcount.hpp
+++ b/include/boost/python/refcount.hpp
@@ -27,12 +27,14 @@ inline T* xincref(T* p)
 template <class T>
 inline void decref(T* p)
 {
+    assert( Py_REFCNT(python::upcast<PyObject>(p)) > 0 );
     Py_DECREF(python::upcast<PyObject>(p));
 }
 
 template <class T>
 inline void xdecref(T* p)
 {
+    assert( !p || Py_REFCNT(python::upcast<PyObject>(p)) > 0 );
     Py_XDECREF(python::upcast<PyObject>(p));
 }
 


### PR DESCRIPTION
Due to programming errors, the reference count may already be zero before trying to decrement it. If nevertheless, the reference count is decremented, the PyObject will be left with a large reference count, pointing to already destroyed memory, possibly resulting in a hard-to-track segmentation fault. This fix introduces assertions that the reference count is above zero before decrementing it, which provide useful indications of this programming error in debug-builds (even when using a release-build of Python).

This [Gist](https://gist.github.com/WKarel/ff9eff5be792e0b4af2f4d12098a1bcb) shows how to produce a situation in which the assertions are helpful.
