### PR TITLE
Add missing .py suffix

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -103,7 +103,7 @@ bpl-test crossmod_exception
 [ bpl-test args ]
 [ bpl-test raw_ctor ]
 [ bpl-test numpy : printer.py numeric_tests.py numarray_tests.py numpy.py numpy.cpp ]
-[ bpl-test enum : test_enum enum_ext.cpp ]
+[ bpl-test enum : test_enum.py enum_ext.cpp ]
 [ bpl-test exception_translator ]
 [ bpl-test pearu1 : test_cltree.py cltree.cpp ]
 [ bpl-test try : newtest.py m1.cpp m2.cpp ]


### PR DESCRIPTION
This breaks the regression test suite