### PR TITLE
Null from override call

### DIFF
--- a/include/boost/python/override.hpp
+++ b/include/boost/python/override.hpp
@@ -96,12 +96,16 @@ class override : public object
     detail::method_result
     operator()() const
     {
-        detail::method_result x(
-            PyEval_CallFunction(
-                this->ptr()
-              , const_cast<char*>("()")
-            ));
-        return x;
+        PyObject* const result = PyEval_CallFunction(
+                                    this->ptr()
+                                    , const_cast<char*>("()")
+                                 );
+
+        if (!result) {
+            throw_error_already_set();
+        }
+
+        return detail::method_result(result);
     }
 
 # define BOOST_PYTHON_fast_arg_to_python_get(z, n, _)   \
@@ -131,13 +135,17 @@ template <
 detail::method_result
 operator()( BOOST_PP_ENUM_BINARY_PARAMS_Z(1, N, A, const& a) ) const
 {
-    detail::method_result x(
-        PyEval_CallFunction(
-            this->ptr()
-          , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
-            BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_fast_arg_to_python_get, nil)
-        ));
-    return x;
+    PyObject* const result = PyEval_CallFunction(
+                                this->ptr()
+                                , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")
+                                  BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_fast_arg_to_python_get, nil)
+                             );
+
+    if (!result) {
+        throw_error_already_set();
+    }
+
+    return detail::method_result(result);
 }
 
 # undef N

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -81,6 +81,7 @@ bpl-test crossmod_exception
   : crossmod_exception.py crossmod_exception_a.cpp crossmod_exception_b.cpp
 ]
 
+[ bpl-test override_null ]
 [ bpl-test injected ]
 [ bpl-test properties ]
 [ bpl-test return_arg ]

--- a/test/SConscript
+++ b/test/SConscript
@@ -91,7 +91,8 @@ for test in [('injected',),
              ('docstring',),
              ('pytype_function',),
              ('vector_indexing_suite',),
-             ('pointer_vector',)]:
+             ('pointer_vector',),
+             ('override_null',)]:
     tests+=env.BPLTest(*test)
 
 test = env.BoostRunPythonScript('test_builtin_converters.py')

--- a/test/override_null.cpp
+++ b/test/override_null.cpp
@@ -1,0 +1,31 @@
+// Copyright David Abrahams 2006. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#include <boost/noncopyable.hpp>
+#include <boost/python.hpp>
+
+using namespace boost;
+
+struct foo {
+  virtual PyObject* f() {
+    return NULL;
+  }
+};
+
+struct foo_wrap : foo, python::wrapper<foo> {
+  virtual PyObject* f() {
+    python::override const o = get_override("f");
+    if (o) {
+      return o();
+    } else {
+      return foo::f();
+    }
+  }
+};
+
+BOOST_PYTHON_MODULE(override_null_ext) {
+  python::class_<foo_wrap, noncopyable>("foo"
+    , python::no_init)
+    .def(python::init<>())
+    .def("f", &foo_wrap::f);
+}

--- a/test/override_null.py
+++ b/test/override_null.py
@@ -1,0 +1,26 @@
+import override_null_ext
+
+foo = override_null_ext.foo()
+foo.f()
+
+class PyFoo(override_null_ext.foo):
+    def __init__(self):
+        super(override_null_ext.foo, self).__init__(self)
+
+pyfoo = PyFoo()
+try:
+    thrown = False
+    pyfoo.f()
+except:
+    thrown = True
+assert thrown
+
+class PyFooOverride(override_null_ext.foo):
+    def __init__(self):
+        super(override_null_ext.foo, self).__init__(self)
+
+    def f(self):
+        return None
+
+pyfoo = PyFooOverride()
+pyfoo.f()


### PR DESCRIPTION
---
Ok, so here's a test, but it doesn't actually test the code I changed. The problem occurs when the `PyFooOverride` returns `NULL`. I can't seem to get it to actually do so (I think there's too much crap in between which does other things). The original problem was, I think, something gone terribly wrong inside the Python interpreter, but the code path *is* possible (never would have found this if not).