### PR TITLE
Multiple calling conventions with MSVC14/amd64

### DIFF
--- a/include/boost/python/signature.hpp
+++ b/include/boost/python/signature.hpp
@@ -111,6 +111,7 @@ struct most_derived
 // 'default' calling convention
 
 #  define BOOST_PYTHON_FN_CC
+#  define BOOST_PYTHON_FN_CC_IS_DEFAULT
 
 #  define BOOST_PP_ITERATION_PARAMS_1                                   \
     (3, (0, BOOST_PYTHON_MAX_ARITY, <boost/python/signature.hpp>))
@@ -118,6 +119,7 @@ struct most_derived
 #  include BOOST_PP_ITERATE()
 
 #  undef BOOST_PYTHON_FN_CC
+#  undef BOOST_PYTHON_FN_CC_IS_DEFAULT
 
 // __cdecl calling convention
 
@@ -141,6 +143,7 @@ struct most_derived
 #  if defined(BOOST_PYTHON_ENABLE_STDCALL)
 
 #   define BOOST_PYTHON_FN_CC __stdcall
+#   define BOOST_PYTHON_FN_CC_IS_STDCALL
 
 #   define BOOST_PP_ITERATION_PARAMS_1                                   \
      (3, (0, BOOST_PYTHON_MAX_ARITY, <boost/python/signature.hpp>))
@@ -148,6 +151,7 @@ struct most_derived
 #   include BOOST_PP_ITERATE()
 
 #   undef BOOST_PYTHON_FN_CC
+#   undef BOOST_PYTHON_FN_CC_IS_STDCALL
 
 #  endif // defined(BOOST_PYTHON_ENABLE_STDCALL)
 
@@ -156,12 +160,14 @@ struct most_derived
 #  if defined(BOOST_PYTHON_ENABLE_FASTCALL)
 
 #   define BOOST_PYTHON_FN_CC __fastcall
+#   define BOOST_PYTHON_FN_CC_IS_FASTCALL
 
 #   define BOOST_PP_ITERATION_PARAMS_1                                   \
      (3, (0, BOOST_PYTHON_MAX_ARITY, <boost/python/signature.hpp>))
 
 #   include BOOST_PP_ITERATE()
 
+#   undef BOOST_PYTHON_FN_CC_IS_FASTCALL
 #   undef BOOST_PYTHON_FN_CC
 
 #  endif // defined(BOOST_PYTHON_ENABLE_FASTCALL)
@@ -184,8 +190,8 @@ struct most_derived
 
    // as 'get_signature(RT(*)(T0...TN), void* = 0)' is the same
    // function as 'get_signature(RT(__cdecl *)(T0...TN), void* = 0)',
-   // we don't define it twice
-#  if !defined(BOOST_PYTHON_FN_CC_IS_CDECL)
+   // we don't define it multiple times (i.e. for __cdecl, __stdcall ...)
+#  if defined(BOOST_PYTHON_FN_CC_IS_DEFAULT)
 
 template <
     class RT BOOST_PP_ENUM_TRAILING_PARAMS_Z(1, N, class T)>
@@ -198,7 +204,7 @@ get_signature(RT(BOOST_PYTHON_FN_CC *)(BOOST_PP_ENUM_PARAMS_Z(1, N, T)), void* =
         >();
 }
 
-#  endif // !defined(BOOST_PYTHON_FN_CC_IS_CDECL)
+#  endif  // BOOST_PYTHON_FN_CC_IS_DEFAULT
 
 # undef N
 
@@ -206,10 +212,12 @@ get_signature(RT(BOOST_PYTHON_FN_CC *)(BOOST_PP_ENUM_PARAMS_Z(1, N, T)), void* =
     (3, (0, 3, <boost/python/signature.hpp>))
 # include BOOST_PP_ITERATE()
 
-#else
+#else  // BOOST_PP_ITERATION_DEPTH() != 1
 
 # define N BOOST_PP_RELATIVE_ITERATION(1)
 # define Q BOOST_PYTHON_CV_QUALIFIER(BOOST_PP_ITERATION())
+
+#  if defined(BOOST_PYTHON_FN_CC_IS_DEFAULT)
 
 template <
     class RT, class ClassT BOOST_PP_ENUM_TRAILING_PARAMS_Z(1, N, class T)>
@@ -244,6 +252,8 @@ get_signature(
         BOOST_PP_ENUM_TRAILING_PARAMS_Z(1, N, T)
     >();
 }
+
+#  endif  // BOOST_PYTHON_FN_CC_IS_DEFAULT
 
 # undef Q
 # undef N


### PR DESCRIPTION
Avoid multiple template instances of boost::python::details::get_signature when multiple calling conventions are enabled