### PR TITLE
Add Python ABI suffix to libboost_python

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -61,6 +61,9 @@ def set_property(env, **kw):
 def boost_suffix(env):
     suffix = str()
 
+    for lib in env["PYTHONLIBS"]:
+        if lib.startswith("python"):
+            suffix += "-" + lib[len("python"):]
     if env["layout"] == "versioned":
         if "gcc" in env["TOOLS"]:
             suffix += "-gcc" + "".join(env["CCVERSION"].split(".")[0:2])


### PR DESCRIPTION
Try to implement my request at issue #82.
