### PR TITLE
Fix a problem where test_builtin_converters.py is not being run

### DIFF
--- a/test/test_builtin_converters.py
+++ b/test/test_builtin_converters.py
@@ -1,9 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-import sys
-if (sys.version_info.major >= 3):
-    long = int
 r"""
 >>> from builtin_converters_ext import *
 
@@ -282,6 +279,10 @@ Check that classic classes also work
 
 >>> assert return_null_handle() is None
 """
+
+import sys
+if (sys.version_info.major >= 3):
+    long = int
 
 def run(args = None):
     import sys


### PR DESCRIPTION
This was happening because the module docstring was not the first statement.