### PR TITLE
Fix for missing export symbols, issue #98

### DIFF
--- a/build/Jamfile
+++ b/build/Jamfile
@@ -137,6 +137,8 @@ rule lib_boost_numpy ( is-py3 ? )
 	numpy/scalars.cpp
 	numpy/ufunc.cpp
         :   # requirements
+            <link>static:<define>BOOST_NUMPY_STATIC_LIB 
+            <define>BOOST_NUMPY_SOURCE
             [ cond [ python.numpy ] : <library>/python//python_for_extensions ]
             [ unless [ python.numpy ] : <build>no ]
 	    <include>$(numpy-include)
@@ -150,6 +152,7 @@ rule lib_boost_numpy ( is-py3 ? )
         :   # default build
             <link>shared
         :   # usage requirements
+			<link>static:<define>BOOST_NUMPY_STATIC_LIB
             <python-debugging>on:<define>BOOST_DEBUG_PYTHON
         ;
 }

--- a/include/boost/python/numpy.hpp
+++ b/include/boost/python/numpy.hpp
@@ -13,6 +13,7 @@
 #include <boost/python/numpy/matrix.hpp>
 #include <boost/python/numpy/ufunc.hpp>
 #include <boost/python/numpy/invoke_matching.hpp>
+#include <boost/python/numpy/config.hpp>
 
 namespace boost { namespace python { namespace numpy {
 
@@ -26,7 +27,7 @@ namespace boost { namespace python { namespace numpy {
  *            and "import_ufunc()", and then calls
  *            dtype::register_scalar_converters().
  */
-void initialize(bool register_scalar_converters=true);
+BOOST_NUMPY_DECL void initialize(bool register_scalar_converters=true);
 
 }}} // namespace boost::python::numpy
 

--- a/include/boost/python/numpy/config.hpp
+++ b/include/boost/python/numpy/config.hpp
@@ -12,6 +12,8 @@
 #ifndef CONFIG_NUMPY20170215_H_
 # define CONFIG_NUMPY20170215_H_
 
+# include <boost/config.hpp>
+
 /*****************************************************************************
  *
  *  Set up dll import/export options:

--- a/include/boost/python/numpy/config.hpp
+++ b/include/boost/python/numpy/config.hpp
@@ -12,9 +12,6 @@
 #ifndef CONFIG_NUMPY20170215_H_
 # define CONFIG_NUMPY20170215_H_
 
-# include <boost/config.hpp>
-# include <boost/detail/workaround.hpp>
-
 /*****************************************************************************
  *
  *  Set up dll import/export options:

--- a/include/boost/python/numpy/config.hpp
+++ b/include/boost/python/numpy/config.hpp
@@ -15,41 +15,6 @@
 # include <boost/config.hpp>
 # include <boost/detail/workaround.hpp>
 
-# ifdef BOOST_NO_OPERATORS_IN_NAMESPACE
-   // A gcc bug forces some symbols into the global namespace
-#  define BOOST_NUMPY_BEGIN_CONVERSION_NAMESPACE
-#  define BOOST_NUMPY_END_CONVERSION_NAMESPACE
-#  define BOOST_NUMPY_CONVERSION
-#  define BOOST_NUMPY_IMPORT_CONVERSION(x) using ::x
-# else
-#  define BOOST_NUMPY_BEGIN_CONVERSION_NAMESPACE namespace boost { namespace python { namespace numpy {
-#  define BOOST_NUMPY_END_CONVERSION_NAMESPACE }} // namespace boost::python
-#  define BOOST_NUMPY_CONVERSION boost::python
-#  define BOOST_NUMPY_IMPORT_CONVERSION(x) void never_defined() // so we can follow the macro with a ';'
-# endif
-
-# if defined(BOOST_MSVC)
-
-#  pragma warning (disable : 4786) // disable truncated debug symbols
-#  pragma warning (disable : 4251) // disable exported dll function
-#  pragma warning (disable : 4800) //'int' : forcing value to bool 'true' or 'false'
-#  pragma warning (disable : 4275) // non dll-interface class
-
-# elif defined(__ICL) && __ICL < 600 // Intel C++ 5
-
-#  pragma warning(disable: 985) // identifier was truncated in debug information
-
-# endif
-
-// The STLport puts all of the standard 'C' library names in std (as far as the
-// user is concerned), but without it you need a fix if you're using MSVC or
-// Intel C++
-# if defined(BOOST_NO_STDC_NAMESPACE)
-#  define BOOST_CSTD_
-# else
-#  define BOOST_CSTD_ std
-# endif
-
 /*****************************************************************************
  *
  *  Set up dll import/export options:
@@ -91,14 +56,6 @@
 #  define BOOST_NUMPY_DECL_EXCEPTION
 #endif
 
-#if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))
-// Replace broken Tru64/cxx offsetof macro
-# define BOOST_NUMPY_OFFSETOF(s_name, s_member) \
-        ((size_t)__INTADDR__(&(((s_name *)0)->s_member)))
-#else
-# define BOOST_NUMPY_OFFSETOF offsetof
-#endif
-
 //  enable automatic library variant selection  ------------------------------// 
 
 #if !defined(BOOST_NUMPY_SOURCE) && !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_NUMPY_NO_LIB)
@@ -106,7 +63,7 @@
 // Set the name of our library, this will get undef'ed by auto_link.hpp
 // once it's done with it:
 //
-#define BOOST_LIB_NAME boost_python
+#define BOOST_LIB_NAME boost_numpy
 //
 // If we're importing code from a dll, then tell auto_link.hpp about it:
 //
@@ -118,13 +75,5 @@
 //
 #include <boost/config/auto_link.hpp>
 #endif  // auto-linking disabled
-
-#ifndef BOOST_NUMPY_NO_PY_SIGNATURES
-#define BOOST_NUMPY_SUPPORTS_PY_SIGNATURES // enables smooth transition
-#endif
-
-#if !defined(BOOST_ATTRIBUTE_UNUSED) && defined(__GNUC__) && (__GNUC__ >= 4)
-#  define BOOST_ATTRIBUTE_UNUSED __attribute__((unused))
-#endif
 
 #endif // CONFIG_NUMPY20170215_H_

--- a/include/boost/python/numpy/config.hpp
+++ b/include/boost/python/numpy/config.hpp
@@ -1,0 +1,130 @@
+//  (C) Copyright Samuli-Petrus Korhonen 2017.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+//  The author gratefully acknowleges the support of NMR Solutions, Inc., in
+//  producing this work.
+
+//  Revision History:
+//  15 Feb 17  Initial version
+
+#ifndef CONFIG_NUMPY20170215_H_
+# define CONFIG_NUMPY20170215_H_
+
+# include <boost/config.hpp>
+# include <boost/detail/workaround.hpp>
+
+# ifdef BOOST_NO_OPERATORS_IN_NAMESPACE
+   // A gcc bug forces some symbols into the global namespace
+#  define BOOST_NUMPY_BEGIN_CONVERSION_NAMESPACE
+#  define BOOST_NUMPY_END_CONVERSION_NAMESPACE
+#  define BOOST_NUMPY_CONVERSION
+#  define BOOST_NUMPY_IMPORT_CONVERSION(x) using ::x
+# else
+#  define BOOST_NUMPY_BEGIN_CONVERSION_NAMESPACE namespace boost { namespace python { namespace numpy {
+#  define BOOST_NUMPY_END_CONVERSION_NAMESPACE }} // namespace boost::python
+#  define BOOST_NUMPY_CONVERSION boost::python
+#  define BOOST_NUMPY_IMPORT_CONVERSION(x) void never_defined() // so we can follow the macro with a ';'
+# endif
+
+# if defined(BOOST_MSVC)
+
+#  pragma warning (disable : 4786) // disable truncated debug symbols
+#  pragma warning (disable : 4251) // disable exported dll function
+#  pragma warning (disable : 4800) //'int' : forcing value to bool 'true' or 'false'
+#  pragma warning (disable : 4275) // non dll-interface class
+
+# elif defined(__ICL) && __ICL < 600 // Intel C++ 5
+
+#  pragma warning(disable: 985) // identifier was truncated in debug information
+
+# endif
+
+// The STLport puts all of the standard 'C' library names in std (as far as the
+// user is concerned), but without it you need a fix if you're using MSVC or
+// Intel C++
+# if defined(BOOST_NO_STDC_NAMESPACE)
+#  define BOOST_CSTD_
+# else
+#  define BOOST_CSTD_ std
+# endif
+
+/*****************************************************************************
+ *
+ *  Set up dll import/export options:
+ *
+ ****************************************************************************/
+
+// backwards compatibility:
+#ifdef BOOST_NUMPY_STATIC_LIB
+#  define BOOST_NUMPY_STATIC_LINK
+# elif !defined(BOOST_NUMPY_DYNAMIC_LIB)
+#  define BOOST_NUMPY_DYNAMIC_LIB
+#endif
+
+#if defined(BOOST_NUMPY_DYNAMIC_LIB)
+#  if defined(BOOST_SYMBOL_EXPORT)
+#     if defined(BOOST_NUMPY_SOURCE)
+#        define BOOST_NUMPY_DECL           BOOST_SYMBOL_EXPORT
+#        define BOOST_NUMPY_DECL_FORWARD   BOOST_SYMBOL_FORWARD_EXPORT
+#        define BOOST_NUMPY_DECL_EXCEPTION BOOST_EXCEPTION_EXPORT
+#        define BOOST_NUMPY_BUILD_DLL
+#     else
+#        define BOOST_NUMPY_DECL           BOOST_SYMBOL_IMPORT
+#        define BOOST_NUMPY_DECL_FORWARD   BOOST_SYMBOL_FORWARD_IMPORT
+#        define BOOST_NUMPY_DECL_EXCEPTION BOOST_EXCEPTION_IMPORT
+#     endif
+#  endif
+
+#endif
+
+#ifndef BOOST_NUMPY_DECL
+#  define BOOST_NUMPY_DECL
+#endif
+
+#ifndef BOOST_NUMPY_DECL_FORWARD
+#  define BOOST_NUMPY_DECL_FORWARD
+#endif
+
+#ifndef BOOST_NUMPY_DECL_EXCEPTION
+#  define BOOST_NUMPY_DECL_EXCEPTION
+#endif
+
+#if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))
+// Replace broken Tru64/cxx offsetof macro
+# define BOOST_NUMPY_OFFSETOF(s_name, s_member) \
+        ((size_t)__INTADDR__(&(((s_name *)0)->s_member)))
+#else
+# define BOOST_NUMPY_OFFSETOF offsetof
+#endif
+
+//  enable automatic library variant selection  ------------------------------// 
+
+#if !defined(BOOST_NUMPY_SOURCE) && !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_NUMPY_NO_LIB)
+//
+// Set the name of our library, this will get undef'ed by auto_link.hpp
+// once it's done with it:
+//
+#define BOOST_LIB_NAME boost_python
+//
+// If we're importing code from a dll, then tell auto_link.hpp about it:
+//
+#ifdef BOOST_NUMPY_DYNAMIC_LIB
+#  define BOOST_DYN_LINK
+#endif
+//
+// And include the header that does the work:
+//
+#include <boost/config/auto_link.hpp>
+#endif  // auto-linking disabled
+
+#ifndef BOOST_NUMPY_NO_PY_SIGNATURES
+#define BOOST_NUMPY_SUPPORTS_PY_SIGNATURES // enables smooth transition
+#endif
+
+#if !defined(BOOST_ATTRIBUTE_UNUSED) && defined(__GNUC__) && (__GNUC__ >= 4)
+#  define BOOST_ATTRIBUTE_UNUSED __attribute__((unused))
+#endif
+
+#endif // CONFIG_NUMPY20170215_H_

--- a/include/boost/python/numpy/dtype.hpp
+++ b/include/boost/python/numpy/dtype.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/python.hpp>
 #include <boost/python/numpy/numpy_object_mgr_traits.hpp>
+#include <boost/python/numpy/config.hpp>
 
 #include <boost/mpl/for_each.hpp>
 #include <boost/type_traits/add_pointer.hpp>
@@ -25,7 +26,7 @@ namespace boost { namespace python { namespace numpy {
  *
  *  @todo This could have a lot more interesting accessors.
  */
-class dtype : public object {
+class BOOST_NUMPY_DECL dtype : public object {
   static python::detail::new_reference convert(object::object_cref arg, bool align);
 public:
 

--- a/include/boost/python/numpy/matrix.hpp
+++ b/include/boost/python/numpy/matrix.hpp
@@ -14,6 +14,8 @@
 #include <boost/python.hpp>
 #include <boost/python/numpy/numpy_object_mgr_traits.hpp>
 #include <boost/python/numpy/ndarray.hpp>
+#include <boost/python/numpy/config.hpp>
+
 
 namespace boost { namespace python { namespace numpy {
 
@@ -27,7 +29,7 @@ namespace boost { namespace python { namespace numpy {
  *            bad things happen when Python shuts down.  I think this solution is safe, but I'd
  *            love to get that confirmed.
  */
-class matrix : public ndarray 
+class BOOST_NUMPY_DECL matrix : public ndarray 
 {
   static object construct(object_cref obj, dtype const & dt, bool copy);
   static object construct(object_cref obj, bool copy);
@@ -59,7 +61,7 @@ public:
  *         return a numpy.matrix instead.
  */
 template <typename Base = default_call_policies>
-struct as_matrix : Base
+struct BOOST_NUMPY_DECL as_matrix : Base
 {
   static PyObject * postcall(PyObject *, PyObject * result)
   {

--- a/include/boost/python/numpy/ndarray.hpp
+++ b/include/boost/python/numpy/ndarray.hpp
@@ -16,6 +16,8 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/python/numpy/numpy_object_mgr_traits.hpp>
 #include <boost/python/numpy/dtype.hpp>
+#include <boost/python/numpy/config.hpp>
+
 #include <vector>
 
 namespace boost { namespace python { namespace numpy {
@@ -26,7 +28,8 @@ namespace boost { namespace python { namespace numpy {
  *  @todo This could have a lot more functionality (like boost::python::numeric::array).
  *        Right now all that exists is what was needed to move raw data between C++ and Python.
  */
-class ndarray : public object
+ 
+class BOOST_NUMPY_DECL ndarray : public object
 {
 
   /**

--- a/include/boost/python/numpy/ufunc.hpp
+++ b/include/boost/python/numpy/ufunc.hpp
@@ -15,6 +15,7 @@
 #include <boost/python/numpy/numpy_object_mgr_traits.hpp>
 #include <boost/python/numpy/dtype.hpp>
 #include <boost/python/numpy/ndarray.hpp>
+#include <boost/python/numpy/config.hpp>
 
 namespace boost { namespace python { namespace numpy {
 
@@ -34,7 +35,7 @@ namespace boost { namespace python { namespace numpy {
  *        It's more dangerous than most object managers, however - maybe it actually belongs in
  *        a detail namespace?
  */
-class multi_iter : public object
+class BOOST_NUMPY_DECL multi_iter : public object
 {
 public:
 


### PR DESCRIPTION
Fix for missing export symbols in shared library of boost::python::numpy as reported and discussed in issue #98. Added config.hpp modified from python/detail/config.hpp for also numpy. Also added export declaration to functions/classes, 