### PR TITLE
Added definition for function checked_downcast_impl

### DIFF
--- a/build/Jamfile
+++ b/build/Jamfile
@@ -69,6 +69,7 @@ rule lib_boost_python ( is-py3 ? )
         converter/from_python.cpp
         converter/registry.cpp
         converter/type_id.cpp
+		converter/pyobject_type.cpp
         object/enum.cpp
         object/class.cpp
         object/function.cpp

--- a/src/converter/pyobject_type.cpp
+++ b/src/converter/pyobject_type.cpp
@@ -1,0 +1,15 @@
+// Copyright David Abrahams 2002.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/python/converter/pyobject_type.hpp>
+
+namespace boost { namespace python { namespace converter { 
+
+PyObject* checked_downcast_impl(PyObject* obj, PyTypeObject* type)
+{
+	return (PyType_IsSubtype(Py_TYPE(obj), type) ? obj : NULL);
+}
+
+}}} // namespace boost::python::conve


### PR DESCRIPTION
Header pyobject_type.hpp defines function checked_downcast_impl but it is not defined anywhere as far as I can see. It is used by pyobject_type::checked_downcast, which is further referenced by boost::numpy in header numpy_object_mgr_traits.hpp.

Also see issue #113. Causes problems under Windows when using shared libraries 