### PR TITLE
Further fix for dll export under windows

### DIFF
--- a/include/boost/python/numpy/dtype.hpp
+++ b/include/boost/python/numpy/dtype.hpp
@@ -56,7 +56,7 @@ public:
    *  This is more permissive than equality tests.  For instance, if long and int are the same
    *  size, the dtypes corresponding to each will be equivalent, but not equal.
    */
-  friend bool equivalent(dtype const & a, dtype const & b);
+  friend BOOST_NUMPY_DECL bool equivalent(dtype const & a, dtype const & b);
 
   /**
    *  @brief Register from-Python converters for NumPy's built-in array scalar types.
@@ -70,7 +70,7 @@ public:
 
 };
 
-bool equivalent(dtype const & a, dtype const & b);
+BOOST_NUMPY_DECL bool equivalent(dtype const & a, dtype const & b);
 
 namespace detail
 {

--- a/include/boost/python/numpy/dtype.hpp
+++ b/include/boost/python/numpy/dtype.hpp
@@ -75,32 +75,32 @@ BOOST_NUMPY_DECL bool equivalent(dtype const & a, dtype const & b);
 namespace detail
 {
 
+template <typename T, bool isInt=boost::is_integral<T>::value> struct builtin_dtype;
+
+//INT INT INT INT INT INT INT INT INT INT INT INT INT INT INT INT INT INT 
+
+template <int bits, bool isUnsigned> struct builtin_int_dtype;
 template <int bits, bool isUnsigned> dtype get_int_dtype();
 
-template <int bits> dtype get_float_dtype();
-
-template <int bits> dtype get_complex_dtype();
-
-template <typename T, bool isInt=boost::is_integral<T>::value>
-struct builtin_dtype;
-
-template <typename T>
-struct builtin_dtype<T,true> {
+template <typename T> struct builtin_dtype<T,true> {
   static dtype get() { return get_int_dtype< 8*sizeof(T), boost::is_unsigned<T>::value >(); }
 };
 
-template <>
-struct builtin_dtype<bool,true> {
-  static dtype get();
-};
+//FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT FLOAT 
+	
+template <int bits> struct builtin_float_dtype;
+template <int bits> dtype get_float_dtype();
 
-template <typename T>
-struct builtin_dtype<T,false> {
+template <typename T> struct builtin_dtype<T,false> {
   static dtype get() { return get_float_dtype< 8*sizeof(T) >(); }
 };
 
-template <typename T>
-struct builtin_dtype< std::complex<T>, false > {
+//COMPLEX COMPLEX COMPLEX COMPLEX COMPLEX COMPLEX COMPLEX COMPLEX COMPLEX 
+	
+template <int bits> struct builtin_complex_dtype;
+template <int bits> dtype get_complex_dtype();
+
+template <typename T> struct builtin_dtype< std::complex<T>, false > {
   static dtype get() { return get_complex_dtype< 16*sizeof(T) >(); }  
 };
 

--- a/include/boost/python/numpy/invoke_matching.hpp
+++ b/include/boost/python/numpy/invoke_matching.hpp
@@ -19,7 +19,7 @@ namespace boost { namespace python { namespace numpy {
 namespace detail 
 {
 
-struct add_pointer_meta 
+struct BOOST_NUMPY_DECL add_pointer_meta 
 {
   template <typename T>
   struct apply 
@@ -29,8 +29,8 @@ struct add_pointer_meta
 
 };
 
-struct dtype_template_match_found {};
-struct nd_template_match_found {};
+struct BOOST_NUMPY_DECL dtype_template_match_found {};
+struct BOOST_NUMPY_DECL nd_template_match_found {};
 
 template <typename Function>
 struct dtype_template_invoker 

--- a/include/boost/python/numpy/matrix.hpp
+++ b/include/boost/python/numpy/matrix.hpp
@@ -61,7 +61,7 @@ public:
  *         return a numpy.matrix instead.
  */
 template <typename Base = default_call_policies>
-struct BOOST_NUMPY_DECL as_matrix : Base
+struct as_matrix : Base
 {
   static PyObject * postcall(PyObject *, PyObject * result)
   {

--- a/include/boost/python/numpy/ndarray.hpp
+++ b/include/boost/python/numpy/ndarray.hpp
@@ -142,27 +142,27 @@ public:
 /**
  *  @brief Construct a new array with the given shape and data type, with data initialized to zero.
  */
-ndarray zeros(python::tuple const & shape, dtype const & dt);
-ndarray zeros(int nd, Py_intptr_t const * shape, dtype const & dt);
+BOOST_NUMPY_DECL ndarray zeros(python::tuple const & shape, dtype const & dt);
+BOOST_NUMPY_DECL ndarray zeros(int nd, Py_intptr_t const * shape, dtype const & dt);
 
 /**
  *  @brief Construct a new array with the given shape and data type, with data left uninitialized.
  */
-ndarray empty(python::tuple const & shape, dtype const & dt);
-ndarray empty(int nd, Py_intptr_t const * shape, dtype const & dt);
+BOOST_NUMPY_DECL ndarray empty(python::tuple const & shape, dtype const & dt);
+BOOST_NUMPY_DECL ndarray empty(int nd, Py_intptr_t const * shape, dtype const & dt);
 
 /**
  *  @brief Construct a new array from an arbitrary Python sequence.
  *
  *  @todo This does't seem to handle ndarray subtypes the same way that "numpy.array" does in Python.
  */
-ndarray array(object const & obj);
-ndarray array(object const & obj, dtype const & dt);
+BOOST_NUMPY_DECL ndarray array(object const & obj);
+BOOST_NUMPY_DECL ndarray array(object const & obj, dtype const & dt);
 
 namespace detail 
 {
 
-ndarray from_data_impl(void * data,
+BOOST_NUMPY_DECL ndarray from_data_impl(void * data,
 		       dtype const & dt,
 		       std::vector<Py_intptr_t> const & shape,
 		       std::vector<Py_intptr_t> const & strides,
@@ -183,7 +183,7 @@ ndarray from_data_impl(void * data,
   return from_data_impl(data, dt, shape_, strides_, owner, writeable);    
 }
 
-ndarray from_data_impl(void * data,
+BOOST_NUMPY_DECL ndarray from_data_impl(void * data,
 		       dtype const & dt,
 		       object const & shape,
 		       object const & strides,
@@ -250,39 +250,39 @@ inline ndarray from_data(void const * data,
  *  @param[in] nd_max  Maximum number of dimensions.
  *  @param[in] flags   Bitwise OR of flags specifying additional requirements.
  */
-ndarray from_object(object const & obj, dtype const & dt,
+BOOST_NUMPY_DECL ndarray from_object(object const & obj, dtype const & dt,
                     int nd_min, int nd_max, ndarray::bitflag flags=ndarray::NONE);
 
-inline ndarray from_object(object const & obj, dtype const & dt,
+BOOST_NUMPY_DECL inline ndarray from_object(object const & obj, dtype const & dt,
                            int nd, ndarray::bitflag flags=ndarray::NONE)
 {
   return from_object(obj, dt, nd, nd, flags);
 }
 
-inline ndarray from_object(object const & obj, dtype const & dt, ndarray::bitflag flags=ndarray::NONE)
+BOOST_NUMPY_DECL inline ndarray from_object(object const & obj, dtype const & dt, ndarray::bitflag flags=ndarray::NONE)
 {
   return from_object(obj, dt, 0, 0, flags);
 }
 
-ndarray from_object(object const & obj, int nd_min, int nd_max,
+BOOST_NUMPY_DECL ndarray from_object(object const & obj, int nd_min, int nd_max,
                     ndarray::bitflag flags=ndarray::NONE);
 
-inline ndarray from_object(object const & obj, int nd, ndarray::bitflag flags=ndarray::NONE)
+BOOST_NUMPY_DECL inline ndarray from_object(object const & obj, int nd, ndarray::bitflag flags=ndarray::NONE)
 {
   return from_object(obj, nd, nd, flags);
 }
 
-inline ndarray from_object(object const & obj, ndarray::bitflag flags=ndarray::NONE)
+BOOST_NUMPY_DECL inline ndarray from_object(object const & obj, ndarray::bitflag flags=ndarray::NONE)
 {
   return from_object(obj, 0, 0, flags);
 }
 
-inline ndarray::bitflag operator|(ndarray::bitflag a, ndarray::bitflag b)
+BOOST_NUMPY_DECL inline ndarray::bitflag operator|(ndarray::bitflag a, ndarray::bitflag b)
 {
   return ndarray::bitflag(int(a) | int(b));
 }
 
-inline ndarray::bitflag operator&(ndarray::bitflag a, ndarray::bitflag b)
+BOOST_NUMPY_DECL inline ndarray::bitflag operator&(ndarray::bitflag a, ndarray::bitflag b)
 {
   return ndarray::bitflag(int(a) & int(b));
 }

--- a/include/boost/python/numpy/numpy_object_mgr_traits.hpp
+++ b/include/boost/python/numpy/numpy_object_mgr_traits.hpp
@@ -7,6 +7,8 @@
 #ifndef boost_python_numpy_numpy_object_mgr_traits_hpp_
 #define boost_python_numpy_numpy_object_mgr_traits_hpp_
 
+#include <boost/python/numpy/config.hpp>
+
 /**
  *  @brief Macro that specializes object_manager_traits by requiring a 
  *         source-file implementation of get_pytype().
@@ -14,7 +16,7 @@
 
 #define NUMPY_OBJECT_MANAGER_TRAITS(manager)                            \
 template <>								\
-struct object_manager_traits<manager>					\
+struct BOOST_NUMPY_DECL object_manager_traits<manager>					\
 {									\
   BOOST_STATIC_CONSTANT(bool, is_specialized = true);			\
   static inline python::detail::new_reference adopt(PyObject* x)	\

--- a/include/boost/python/numpy/scalars.hpp
+++ b/include/boost/python/numpy/scalars.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace python { namespace numpy {
  *
  *  @todo This could have a lot more functionality.
  */
-class void_ : public object
+class BOOST_NUMPY_DECL void_ : public object
 {
   static python::detail::new_reference convert(object_cref arg, bool align);
 public:

--- a/include/boost/python/numpy/ufunc.hpp
+++ b/include/boost/python/numpy/ufunc.hpp
@@ -62,13 +62,13 @@ public:
 };
 
 /// @brief Construct a multi_iter over a single sequence or scalar object.
-multi_iter make_multi_iter(object const & a1);
+BOOST_NUMPY_DECL multi_iter make_multi_iter(object const & a1);
 
 /// @brief Construct a multi_iter by broadcasting two objects.
-multi_iter make_multi_iter(object const & a1, object const & a2);
+BOOST_NUMPY_DECL multi_iter make_multi_iter(object const & a1, object const & a2);
 
 /// @brief Construct a multi_iter by broadcasting three objects.
-multi_iter make_multi_iter(object const & a1, object const & a2, object const & a3);
+BOOST_NUMPY_DECL multi_iter make_multi_iter(object const & a1, object const & a2, object const & a3);
 
 /**
  *  @brief Helps wrap a C++ functor taking a single scalar argument as a broadcasting ufunc-like
@@ -94,7 +94,7 @@ multi_iter make_multi_iter(object const & a1, object const & a2, object const & 
 template <typename TUnaryFunctor, 
           typename TArgument=typename TUnaryFunctor::argument_type,
           typename TResult=typename TUnaryFunctor::result_type>
-struct unary_ufunc 
+struct BOOST_NUMPY_DECL unary_ufunc 
 {
 
   /**
@@ -158,7 +158,7 @@ template <typename TBinaryFunctor,
           typename TArgument1=typename TBinaryFunctor::first_argument_type,
           typename TArgument2=typename TBinaryFunctor::second_argument_type,
           typename TResult=typename TBinaryFunctor::result_type>
-struct binary_ufunc 
+struct BOOST_NUMPY_DECL binary_ufunc 
 {
 
   static object


### PR DESCRIPTION
There was still some issues using boost::python::numpy under windows as a shared library. At least under MSVC using builtin dtypes is fragile and creates semi-random segfaults. 

This pull request fixes the remaining export issues and fixes the segfault in dtype