### PR TITLE
Reencoded a few headers that used Windows-1252 with UTF-8.

### DIFF
--- a/include/boost/python/detail/dealloc.hpp
+++ b/include/boost/python/detail/dealloc.hpp
@@ -1,4 +1,4 @@
-// Copyright Gottfried Ganﬂauge 2003.
+// Copyright Gottfried Gan√üauge 2003.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/python/opaque_pointer_converter.hpp
+++ b/include/boost/python/opaque_pointer_converter.hpp
@@ -1,4 +1,4 @@
-// Copyright Gottfried Ganﬂauge 2003..2006.
+// Copyright Gottfried Gan√üauge 2003..2006.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/python/return_opaque_pointer.hpp
+++ b/include/boost/python/return_opaque_pointer.hpp
@@ -1,4 +1,4 @@
-// Copyright Gottfried Ganﬂauge 2003.
+// Copyright Gottfried Gan√üauge 2003.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/test/crossmod_opaque.py
+++ b/test/crossmod_opaque.py
@@ -1,5 +1,5 @@
 # -*- coding: latin-1 -*-
-# Copyright Gottfried Ganßauge 2006.
+# Copyright Gottfried GanÃŸauge 2006.
 # Distributed under the Boost Software License, Version 1.0. (See
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/test/crossmod_opaque_a.cpp
+++ b/test/crossmod_opaque_a.cpp
@@ -1,4 +1,4 @@
-// Copyright Gottfried Ganﬂauge 2006.
+// Copyright Gottfried Gan√üauge 2006.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/test/crossmod_opaque_b.cpp
+++ b/test/crossmod_opaque_b.cpp
@@ -1,4 +1,4 @@
-// Copyright Gottfried Ganﬂauge 2006.
+// Copyright Gottfried Gan√üauge 2006.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/test/opaque.py
+++ b/test/opaque.py
@@ -1,5 +1,5 @@
 # -*- coding: latin-1 -*-
-# Copyright Gottfried Ganßauge 2003..2006.  Distributed under the Boost
+# Copyright Gottfried GanÃŸauge 2003..2006.  Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 


### PR DESCRIPTION
Nearly every header in the boost codebase is UTF-8, but here there
are a few headers which are using Windows-1252, which makes it impossible
for some tools to parse those files. This patch just reencodes them
with UTF-8 like the rest of the codebase. I checked that the name of the
author is still correct after this change.

No functional change intended.