### PR TITLE
Fix `BOOST_LIB_NAME` for Python 3

### DIFF
--- a/include/boost/python/detail/config.hpp
+++ b/include/boost/python/detail/config.hpp
@@ -105,7 +105,11 @@
 // Set the name of our library, this will get undef'ed by auto_link.hpp
 // once it's done with it:
 //
-#define BOOST_LIB_NAME boost_python
+#if PY_MAJOR_VERSION == 2
+#  define BOOST_LIB_NAME boost_python
+#elif PY_MAJOR_VERSION == 3
+#  define BOOST_LIB_NAME boost_python3
+#endif
 //
 // If we're importing code from a dll, then tell auto_link.hpp about it:
 //

--- a/include/boost/python/numpy/config.hpp
+++ b/include/boost/python/numpy/config.hpp
@@ -62,7 +62,11 @@
 // Set the name of our library, this will get undef'ed by auto_link.hpp
 // once it's done with it:
 //
-#define BOOST_LIB_NAME boost_numpy
+#if PY_MAJOR_VERSION == 2
+#  define BOOST_LIB_NAME boost_numpy
+#elif PY_MAJOR_VERSION == 3
+#  define BOOST_LIB_NAME boost_numpy3
+#endif
 //
 // If we're importing code from a dll, then tell auto_link.hpp about it:
 //


### PR DESCRIPTION
Fixes https://github.com/boostorg/python/issues/127

This was reusing the Python 2 name on Python 3, which is incorrect since the Python 3 library for Boost.Python now has a `3` in it. Hence this checks against the Python version and defines this correctly.