### PR TITLE
Fix wrong and unused macro name while use BOOST_PP

### DIFF
--- a/include/boost/python/numeric.hpp
+++ b/include/boost/python/numeric.hpp
@@ -216,7 +216,7 @@ class array : public aux::array_base
     {}
 # define BOOST_PP_LOCAL_LIMITS (1, 7)
 # include BOOST_PP_LOCAL_ITERATE()
-# undef BOOST_PYTHON_AS_OBJECT
+# undef BOOST_PYTHON_ENUM_AS_OBJECT
 
     static BOOST_PYTHON_DECL void set_module_and_type(char const* package_name = 0, char const* type_attribute_name = 0);
     static BOOST_PYTHON_DECL std::string get_module_name();

--- a/src/numeric.cpp
+++ b/src/numeric.cpp
@@ -121,14 +121,12 @@ namespace aux
       return downcast<PyTypeObject>(array_type.get());
   }
 
-# define BOOST_PYTHON_AS_OBJECT(z, n, _) object(x##n)
 # define BOOST_PP_LOCAL_MACRO(n)                                        \
     array_base::array_base(BOOST_PP_ENUM_PARAMS(n, object const& x))    \
         : object(demand_array_function()(BOOST_PP_ENUM_PARAMS(n, x)))   \
     {}
 # define BOOST_PP_LOCAL_LIMITS (1, 6)
 # include BOOST_PP_LOCAL_ITERATE()
-# undef BOOST_PYTHON_AS_OBJECT
 
     array_base::array_base(BOOST_PP_ENUM_PARAMS(7, object const& x))
         : object(demand_array_function()(BOOST_PP_ENUM_PARAMS(7, x)))


### PR DESCRIPTION
- `BOOST_PYTHON_AS_OBJECT` in numeric.cpp has never been used
- `BOOST_PYTHON_AS_OBJECT` in numeric.hpp should be `BOOST_PYTHON_ENUM_AS_OBJECT`