### PR TITLE
Fix warning: returning the proper type for object sizes

### DIFF
--- a/include/boost/python/detail/caller.hpp
+++ b/include/boost/python/detail/caller.hpp
@@ -48,7 +48,7 @@ inline PyObject* get(mpl::int_<N>, PyObject* const& args_)
     return PyTuple_GET_ITEM(args_,N);
 }
 
-inline unsigned arity(PyObject* const& args_)
+inline Py_ssize_t arity(PyObject* const& args_)
 {
     return PyTuple_GET_SIZE(args_);
 }


### PR DESCRIPTION
This fixes a small casting warning, and I believe is more correct. I however do not know if this is compatible with python < 2.7