### PR TITLE
Fix for #131 initModule symbol not visible in 1.64

### DIFF
--- a/include/boost/python/object/instance.hpp
+++ b/include/boost/python/object/instance.hpp
@@ -18,7 +18,7 @@ namespace boost { namespace python { namespace objects {
 
 // Each extension instance will be one of these
 template <class Data = char>
-struct instance
+struct BOOST_PYTHON_DECL instance
 {
     PyObject_VAR_HEAD
     PyObject* dict;


### PR DESCRIPTION
If a global visibility is set to 'hidden', importing modules that define classes without either 'noimport' or 'init' causes 
errors like:
`ImportError: dynamic module does not define init function`

This seems to be due to some, probably unintended changes from #1.