### PR TITLE
Fix exception propagation from module init and memory leak

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -21,7 +21,14 @@ namespace
             object m_obj(((borrowed_reference_t*)m));
             scope current_module(m_obj);
 
-            handle_exception(init_function);
+            // If an exception happened we have to return NULL
+            if (handle_exception(init_function))
+            {
+#if PY_VERSION_HEX >= 0x03000000
+                Py_DECREF(m);
+                m = 0;
+#endif
+            }
         }
 
         return m;

--- a/src/object/enum.cpp
+++ b/src/object/enum.cpp
@@ -34,11 +34,17 @@ static PyMemberDef enum_members[] = {
 
 extern "C"
 {
+    static void
+    enum_dealloc(enum_object* self)
+    {
+        Py_XDECREF(self->name);
+        Py_TYPE(self)->tp_free((PyObject*)self);
+    }
+
     static PyObject* enum_repr(PyObject* self_)
     {
-        // XXX(bhy) Potentional memory leak here since PyObject_GetAttrString returns a new reference
-        // const char *mod = PyString_AsString(PyObject_GetAttrString( self_, const_cast<char*>("__module__")));
         PyObject *mod = PyObject_GetAttrString( self_, "__module__");
+        object auto_free(handle<>(mod));
         enum_object* self = downcast<enum_object>(self_);
         if (!self->name)
         {
@@ -88,7 +94,7 @@ static PyTypeObject enum_type_object = {
     const_cast<char*>("Boost.Python.enum"),
     sizeof(enum_object),                    /* tp_basicsize */
     0,                                      /* tp_itemsize */
-    0,                                      /* tp_dealloc */
+    (destructor) enum_dealloc,              /* tp_dealloc */
     0,                                      /* tp_print */
     0,                                      /* tp_getattr */
     0,                                      /* tp_setattr */


### PR DESCRIPTION
Two fixes:

1. For Python3 when exception got raised in module init it got suppressed (see details in 7c3240d)
2. Minor memory leak in `type_id.cpp:gcc_demangle` (see details in 1d19e6f)