### PR TITLE
Fix build with Python 3.7

### DIFF
--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -45,10 +45,15 @@ namespace
   {
       return PyString_Check(obj) ? PyString_AsString(obj) : 0;
   }
-#else
+#elif PY_VERSION_HEX < 0x03070000
   void* convert_to_cstring(PyObject* obj)
   {
       return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+  }
+#else
+  void* convert_to_cstring(PyObject* obj)
+  {
+      return PyUnicode_Check(obj) ? const_cast<void*>(reinterpret_cast<const void*>(_PyUnicode_AsString(obj))) : 0;
   }
 #endif
 


### PR DESCRIPTION
Python 3.7 changes the return type of _PyUnicode_AsString()
from void* to const char* -- causing the build of boost-python
to fail.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>