### PR TITLE
crash when generating sphinx documentation after MSVC upgrade

### DIFF
--- a/src/object/function_doc_signature.cpp
+++ b/src/object/function_doc_signature.cpp
@@ -116,7 +116,7 @@ namespace boost { namespace python { namespace objects {
 
     const  char * function_doc_signature_generator::py_type_str(const python::detail::signature_element &s)
     {
-        if (s.basename==std::string("void")){
+        if (s.basename==nullptr || s.basename==std::string("void")){
             static const char * none = "None";
             return none;
         }


### PR DESCRIPTION
Generating sphinx documentation worked fine for our python embedding dll built with boost python.
After the compiler upgrade to VisualStudio 15.7.2  it always leads to a crash.
Boost or python were not changed, only MSVC. Recompiling boost with the new MSVC didn't help.
I could prevent the access violation with this nullptr check.
I didn't research the root cause further from there. There might be a better solution.