### PR TITLE
Add missing return statement in numpy import

### DIFF
--- a/src/numpy/numpy.cpp
+++ b/src/numpy/numpy.cpp
@@ -19,6 +19,7 @@ static void wrap_import_array()
 static void * wrap_import_array()
 {
   import_array();
+  return NULL;
 }
 #endif
 


### PR DESCRIPTION
This adds a missing return statement in the python3 specific
import logic of boost.python.numpy.

For python3 wrap_import_array() needs to return a pointer value.
The import_array() macro only returns NULL in case of error. The
missing return statement is UB, so the compiler can assume it does
not happen. This means the compiler can assume the error branch
is always taken, so import_array must always fail.

This fixes #214 and #209 