### PR TITLE
Add empty stage/install targets when Python is not configured

### DIFF
--- a/build/Jamfile
+++ b/build/Jamfile
@@ -136,3 +136,14 @@ lib boost_numpy
 boost-install boost_python boost_numpy ;
 
 }
+else
+{
+# Python not configured
+
+alias stage : config-warning ;
+explicit stage ;
+
+alias install : config-warning ;
+explicit install ;
+
+}

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -133,12 +133,24 @@ lib boost_numpy
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
     ;
 
+# boost-install creates `stage` and `install` targets
+#
+# `stage` stages (builds and copies into `stage/lib`) the given libraries
+#   `boost_python` and `boost_numpy` and their dependencies and is similar
+#   to issuing `b2 --with-python stage` from top level
+#
+# `install` installs the two libraries and their dependencies and is similar
+#   to issuing `b2 --with-python install` from top level
+
 boost-install boost_python boost_numpy ;
 
 }
 else
 {
-# Python not configured
+
+# When Python isn't configured, the above `boost-install` is not executed,
+# so we create empty `stage` and `install` targets that do nothing but issue
+# a warning message unless `--without-python` is given
 
 alias stage : config-warning ;
 explicit stage ;


### PR DESCRIPTION
Since the previously added boost-install is in `if [ python.configured ]`, this `else` adds stage/install targets (that issue the preexisting warning message) in case Python hasn't been configured.