### PR TITLE
Fix function_doc_signature_generator::py_type_str causing segfault (issue #240)

### DIFF
--- a/include/boost/python/detail/caller.hpp
+++ b/include/boost/python/detail/caller.hpp
@@ -233,10 +233,11 @@ struct caller_arity<N>
             typedef BOOST_DEDUCED_TYPENAME Policies::template extract_return_type<Sig>::type rtype;
             typedef typename select_result_converter<Policies, rtype>::type result_converter;
 
+            static const std::string rtype_name(is_void<rtype>::value ? "void" : type_id<rtype>().name());
             static const signature_element ret = {
-                (is_void<rtype>::value ? "void" : type_id<rtype>().name())
+                rtype_name.c_str()
                 , &detail::converter_target_type<result_converter>::get_pytype
-                , boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value 
+                , boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value
             };
             py_func_sig_info res = {sig, &ret };
 #else

--- a/src/object/function_doc_signature.cpp
+++ b/src/object/function_doc_signature.cpp
@@ -116,7 +116,7 @@ namespace boost { namespace python { namespace objects {
 
     const  char * function_doc_signature_generator::py_type_str(const python::detail::signature_element &s)
     {
-        if (s.basename==std::string("void")){
+        if (strcmp(s.basename, "void") == 0){
             static const char * none = "None";
             return none;
         }


### PR DESCRIPTION
Issue #240 is apparently caused by `s.basename` vanishing before being evaluated, and thus comparing a `nullpointer`.

Storing the return type's name in a `static std::string` prevents the name from vanishing before being checked.