### PR TITLE
clear python exception after expected attribute lookup failure

### DIFF
--- a/src/object/function.cpp
+++ b/src/object/function.cpp
@@ -444,7 +444,9 @@ void function::add_to_namespace(
         if (dict == 0)
             throw_error_already_set();
 
+        assert(!PyErr_Occurred());
         handle<> existing(allow_null(::PyObject_GetItem(dict.get(), name.ptr())));
+        PyErr_Clear();
         
         if (existing)
         {
@@ -485,16 +487,15 @@ void function::add_to_namespace(
         if (new_func->name().is_none())
             new_func->m_name = name;
 
+        assert(!PyErr_Occurred());
         handle<> name_space_name(
             allow_null(::PyObject_GetAttrString(name_space.ptr(), const_cast<char*>("__name__"))));
+        PyErr_Clear();
         
         if (name_space_name)
             new_func->m_namespace = object(name_space_name);
     }
 
-    // The PyObject_GetAttrString() or PyObject_GetItem calls above may
-    // have left an active error
-    PyErr_Clear();
     if (PyObject_SetAttr(ns, name.ptr(), attribute.ptr()) < 0)
         throw_error_already_set();
 


### PR DESCRIPTION
Python 3.7.0 asserts that attribute lookup functions are called without outstanding exceptions:
https://github.com/python/cpython/blob/v3.7.0a2/Objects/typeobject.c#L3037
Motivation: https://bugs.python.org/issue34068#msg321262
Therefore the error set by the first PyObject_GetItem should be cleared before calling PyObject_GetAttrString.