### PR TITLE
Fix -Wregister error on Clang in C++17 mode

### DIFF
--- a/include/boost/python/detail/wrap_python.hpp
+++ b/include/boost/python/detail/wrap_python.hpp
@@ -145,11 +145,37 @@ typedef int pid_t;
 
 #endif // _WIN32
 
+#if defined(__GNUC__)
+# if defined(__has_warning)
+#  define BOOST_PYTHON_GCC_HAS_WREGISTER __has_warning("-Wregister")
+# else
+#  define BOOST_PYTHON_GCC_HAS_WREGISTER __GNUC__ >= 7
+# endif
+#else
+# define BOOST_PYTHON_GCC_HAS_WREGISTER 0
+#endif
+
+// Python.h header uses `register` keyword until Python 3.4
+#if BOOST_PYTHON_GCC_HAS_WREGISTER
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wregister"
+#elif defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable : 5033)  // 'register' is no longer a supported storage class
+#endif
+
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 2 && PY_MICRO_VERSION < 2
 # include <boost/python/detail/python22_fixed.h>
 #else
 # include <Python.h>
 #endif
+
+#if BOOST_PYTHON_GCC_HAS_WREGISTER
+# pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+# pragma warning(pop)
+#endif
+#undef BOOST_PYTHON_GCC_HAS_WREGISTER
 
 #ifdef BOOST_PYTHON_ULONG_MAX_UNDEFINED
 # undef ULONG_MAX


### PR DESCRIPTION
Suppresses the warning on GCC, Clang, and MSVC.

Probably it is worth cherry-picking into the master as even the release managers had the trouble with Python 2 headers.

Playground: https://godbolt.org/z/ioqTlS
