### PR TITLE
Fixed module tests fail

### DIFF
--- a/test/test_class.hpp
+++ b/test/test_class.hpp
@@ -4,17 +4,17 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 #ifndef TEST_CLASS_DWA2002326_HPP
 # define TEST_CLASS_DWA2002326_HPP
-# include <boost/detail/lightweight_test.hpp>
+# include <boost/assert.hpp>
 
 template <int n = 0>
 struct test_class
 {
     explicit test_class(int x) : x(x), magic(7654321 + n) { ++counter; }
     test_class(test_class const& rhs) : x(rhs.x), magic(7654321 + n) { ++counter; }
-    virtual ~test_class() { BOOST_TEST(magic == 7654321 + n); magic = 6666666; x = 9999; --counter; }
+    virtual ~test_class() { BOOST_ASSERT(magic == 7654321 + n); magic = 6666666; x = 9999; --counter; }
 
-    void set(int _x) { BOOST_TEST(magic == 7654321 + n); this->x = _x; }
-    int value() const { BOOST_TEST(magic == 7654321 + n); return x; }
+    void set(int _x) { BOOST_ASSERT(magic == 7654321 + n); this->x = _x; }
+    int value() const { BOOST_ASSERT(magic == 7654321 + n); return x; }
     operator int() const { return x; }
     static int count() { return counter; }
 


### PR DESCRIPTION
Since recently lightweight_test introduced a sanitation to ensure that `boost::report_errors()` is called, and it does not in module tests.

The problem could be fixed by exporting the function and calling it from these python tests, but as it already done in other module tests I just turned those usages lightweight_test to a regular assertation.

ref #254