### PR TITLE
Only boost-install boost_numpy when it's being built

### DIFF
--- a/build/Jamfile
+++ b/build/Jamfile
@@ -30,8 +30,6 @@ else
         ;
 }
 
-if [ python.configured ]
-{
 project boost/python
   : source-location ../src
   ;
@@ -123,7 +121,7 @@ lib boost_numpy
         <library>boost_python
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
         -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
-	<tag>@$(__name__).python-tag
+        <tag>@$(__name__).python-tag
         <conditional>@python.require-py
 
     :   # default build
@@ -142,8 +140,16 @@ lib boost_numpy
 # `install` installs the two libraries and their dependencies and is similar
 #   to issuing `b2 --with-python install` from top level
 
-boost-install boost_python boost_numpy ;
-
+if [ python.configured ]
+{
+    if [ python.numpy ]
+    {
+        boost-install boost_python boost_numpy ;
+    }
+    else
+    {
+        boost-install boost_python ;
+    }
 }
 else
 {


### PR DESCRIPTION
The library `boost_numpy` is conditioned on `[ python.numpy ]`, so only `boost-install` it when this condition holds.

This also moves the libraries outside `if [ python.configured ]` (as was the case before) since they are already guarded with `[ cond ]`.