### PR TITLE
Make __module__ on function objects consistent with cpython

### DIFF
--- a/include/boost/python/object/function.hpp
+++ b/include/boost/python/object/function.hpp
@@ -40,7 +40,7 @@ struct BOOST_PYTHON_DECL function : PyObject
     
     object const& name() const;
 
-    object const& get_namespace() const { return m_namespace; }
+    object const& get_module() const { return m_module; }
     
  private: // helper functions
     object signature(bool show_return_type=false) const;
@@ -52,7 +52,7 @@ struct BOOST_PYTHON_DECL function : PyObject
     py_function m_fn;
     handle<function> m_overloads;
     object m_name;
-    object m_namespace;
+    object m_module;
     object m_doc;
     object m_arg_names;
     unsigned m_nkeyword_values;

--- a/test/pytype_function.cpp
+++ b/test/pytype_function.cpp
@@ -12,6 +12,7 @@ using namespace boost::python;
 
 struct A
 {
+  void memberfunc(void) {}
 };
 
 struct B
@@ -76,7 +77,7 @@ BOOST_PYTHON_MODULE(pytype_function_ext)
   to_python_converter< B , BToPython,true >(); //has get_pytype
   BFromPython();
 
-  class_<A>("A") ;
+  class_<A>("A").def("memberfunc", &A::memberfunc);
 
   def("func", &func);
 

--- a/test/pytype_function.py
+++ b/test/pytype_function.py
@@ -12,6 +12,16 @@ pytype_function_ext
 
 >>> print(func.__name__)
 func
+
+>>> print(A.memberfunc.__doc__.splitlines()[1])
+memberfunc( (A)arg1) -> None :
+
+>>> print(A.memberfunc.__name__)
+memberfunc
+
+>>> print(A.memberfunc.__module__)
+pytype_function_ext
+
 """
 def run(args = None):
     import sys


### PR DESCRIPTION
This changes the `__module__` attribute of member functions to indicate the module the class is defined in rather than the name of the class.

This new behavior is consistent with cpython's handling of pure python member functions.