### PR TITLE
Replace methods for Py_LIMITED_API support

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,6 +1,6 @@
 name: deploy documentation
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   deploy:

--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -1,6 +1,6 @@
 name: Test OSX
 
-on:  [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -9,16 +9,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [python, python3]
-        cxx: [g++, clang++]
-        std: [c++98, c++11, c++14, c++17]
+        python: [python3]
+        cxx: [g++]
+        std: [c++98]
         include:
           # Add the appropriate docker image for each compiler.
           # The images from teeks99/boost-python-test already have boost::python
           # pre-reqs installed, see:
           # https://github.com/teeks99/boost-python-test-docker
-          - cxx: clang++
-            docker-img: teeks99/boost-python-test:clang-12_1.76.0
+          #- cxx: clang++
+          #  docker-img: teeks99/boost-python-test:clang-12_1.76.0
           - cxx: g++
             docker-img: teeks99/boost-python-test:gcc-10_1.76.0
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,6 @@
 name: Test Windows
 
-on:  [push, pull_request]
+on:  [pull_request]
 
 jobs:
   build:

--- a/include/boost/python/detail/caller.hpp
+++ b/include/boost/python/detail/caller.hpp
@@ -40,17 +40,17 @@
 #  include <boost/mpl/int.hpp>
 #  include <boost/mpl/next.hpp>
 
-namespace boost { namespace python { namespace detail { 
+namespace boost { namespace python { namespace detail {
 
 template <int N>
 inline PyObject* get(mpl::int_<N>, PyObject* const& args_)
 {
-    return PyTuple_GET_ITEM(args_,N);
+    return PyTuple_GetItem(args_,N);
 }
 
 inline Py_ssize_t arity(PyObject* const& args_)
 {
-    return PyTuple_GET_SIZE(args_);
+    return PyTuple_Size(args_);
 }
 
 // This "result converter" is really just used as
@@ -80,7 +80,7 @@ inline ResultConverter create_result_converter(
 {
     return ResultConverter(args_);
 }
-    
+
 template <class ArgPackage, class ResultConverter>
 inline ResultConverter create_result_converter(
     ArgPackage const&
@@ -93,7 +93,7 @@ inline ResultConverter create_result_converter(
 
 #ifndef BOOST_PYTHON_NO_PY_SIGNATURES
 template <class ResultConverter>
-struct converter_target_type 
+struct converter_target_type
 {
     static PyTypeObject const *get_pytype()
     {
@@ -120,7 +120,7 @@ template<class Policies, class Sig> const signature_element* get_ret()
     static const signature_element ret = {
         (is_void<rtype>::value ? "void" : type_id<rtype>().name())
         , &detail::converter_target_type<result_converter>::get_pytype
-        , boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value 
+        , boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value
     };
 
     return &ret;
@@ -128,7 +128,7 @@ template<class Policies, class Sig> const signature_element* get_ret()
 
 #endif
 
-    
+
 template <unsigned> struct caller_arity;
 
 template <class F, class CallPolicies, class Sig>
@@ -187,7 +187,7 @@ struct caller
         >::type base;
 
     typedef PyObject* result_type;
-    
+
     caller(F f, CallPolicies p) : base(f,p) {}
 
 };
@@ -217,14 +217,14 @@ struct caller_arity<N>
             typedef typename first::type result_t;
             typedef typename select_result_converter<Policies, result_t>::type result_converter;
             typedef typename Policies::argument_package argument_package;
-            
+
             argument_package inner_args(args_);
 
 # if N
 #  define BOOST_PP_LOCAL_MACRO(i) BOOST_PYTHON_ARG_CONVERTER(i)
 #  define BOOST_PP_LOCAL_LIMITS (0, N-1)
 #  include BOOST_PP_LOCAL_ITERATE()
-# endif 
+# endif
             // all converters have been checked. Now we can do the
             // precall part of the policy
             if (!m_data.second().precall(inner_args))
@@ -236,17 +236,17 @@ struct caller_arity<N>
               , m_data.first()
                 BOOST_PP_ENUM_TRAILING_PARAMS(N, c)
             );
-            
+
             return m_data.second().postcall(inner_args, result);
         }
 
         static unsigned min_arity() { return N; }
-        
+
         static py_func_sig_info  signature()
         {
             const signature_element * sig = detail::signature<Sig>::elements();
 #ifndef BOOST_PYTHON_NO_PY_SIGNATURES
-            // MSVC 15.7.2, when compiling to /O2 left the static const signature_element ret, 
+            // MSVC 15.7.2, when compiling to /O2 left the static const signature_element ret,
             // originally defined here, uninitialized. This in turn led to SegFault in Python interpreter.
             // Issue is resolved by moving the generation of ret to separate function in detail namespace (see above).
             const signature_element * ret = detail::get_ret<Policies, Sig>();
@@ -265,6 +265,6 @@ struct caller_arity<N>
 
 
 
-#endif // BOOST_PP_IS_ITERATING 
+#endif // BOOST_PP_IS_ITERATING
 
 

--- a/include/boost/python/detail/make_tuple.hpp
+++ b/include/boost/python/detail/make_tuple.hpp
@@ -1,4 +1,4 @@
-# ifndef BOOST_PYTHON_SYNOPSIS 
+# ifndef BOOST_PYTHON_SYNOPSIS
 # // Copyright David Abrahams 2002.
 # // Distributed under the Boost Software License, Version 1.0. (See
 # // accompanying file LICENSE_1_0.txt or copy at
@@ -11,7 +11,7 @@
 #  define N BOOST_PP_ITERATION()
 
 #  define BOOST_PYTHON_MAKE_TUPLE_ARG(z, N, ignored)    \
-    PyTuple_SET_ITEM(                                   \
+    PyTuple_SetItem(                                   \
         result.ptr()                                    \
         , N                                             \
         , python::incref(python::object(a##N).ptr())    \
@@ -29,4 +29,4 @@
 #  undef BOOST_PYTHON_MAKE_TUPLE_ARG
 
 #  undef N
-# endif // BOOST_PYTHON_SYNOPSIS 
+# endif // BOOST_PYTHON_SYNOPSIS

--- a/include/boost/python/detail/wrap_python.hpp
+++ b/include/boost/python/detail/wrap_python.hpp
@@ -22,7 +22,7 @@
 
 #ifdef _DEBUG
 # ifndef BOOST_DEBUG_PYTHON
-#  ifdef _MSC_VER  
+#  ifdef _MSC_VER
     // VC8.0 will complain if system headers are #included both with
     // and without _DEBUG defined, so we have to #include all the
     // system headers used by pyconfig.h right here.
@@ -175,6 +175,7 @@ typedef int pid_t;
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 2 && PY_MICRO_VERSION < 2
 # include <boost/python/detail/python22_fixed.h>
 #else
+#define Py_LIMITED_API
 # include <Python.h>
 #endif
 

--- a/include/boost/python/enum.hpp
+++ b/include/boost/python/enum.hpp
@@ -11,7 +11,7 @@
 # include <boost/python/converter/rvalue_from_python_data.hpp>
 # include <boost/python/converter/registered.hpp>
 
-namespace boost { namespace python { 
+namespace boost { namespace python {
 
 template <class T>
 struct enum_ : public objects::enum_base
@@ -70,7 +70,7 @@ void* enum_<T>::convertible_from_python(PyObject* obj)
         obj
         , upcast<PyObject>(
             converter::registered<T>::converters.m_class_object))
-        
+
         ? obj : 0;
 }
 
@@ -80,9 +80,9 @@ template <class T>
 void enum_<T>::construct(PyObject* obj, converter::rvalue_from_python_stage1_data* data)
 {
 #if PY_VERSION_HEX >= 0x03000000
-    T x = static_cast<T>(PyLong_AS_LONG(obj));
+    T x = static_cast<T>(PyLong_AsLong(obj));
 #else
-    T x = static_cast<T>(PyInt_AS_LONG(obj));
+    T x = static_cast<T>(PyInt_AsLong(obj));
 #endif
     void* const storage = ((converter::rvalue_from_python_storage<T>*)data)->storage.bytes;
     new (storage) T(x);

--- a/include/boost/python/object/make_instance.hpp
+++ b/include/boost/python/object/make_instance.hpp
@@ -14,13 +14,13 @@
 # include <boost/mpl/assert.hpp>
 # include <boost/mpl/or.hpp>
 
-namespace boost { namespace python { namespace objects { 
+namespace boost { namespace python { namespace objects {
 
 template <class T, class Holder, class Derived>
 struct make_instance_impl
 {
     typedef objects::instance<Holder> instance_t;
-        
+
     template <class Arg>
     static inline PyObject* execute(Arg& x)
     {
@@ -32,20 +32,20 @@ struct make_instance_impl
         if (type == 0)
             return python::detail::none();
 
-        PyObject* raw_result = type->tp_alloc(
+        PyObject* raw_result = type->Py_tp_alloc(
             type, objects::additional_instance_size<Holder>::value);
-          
+
         if (raw_result != 0)
         {
             python::detail::decref_guard protect(raw_result);
-            
+
             instance_t* instance = (instance_t*)raw_result;
-            
+
             // construct the new C++ object and install the pointer
             // in the Python object.
             Holder *holder =Derived::construct(instance->storage.bytes, (PyObject*)instance, x);
             holder->install(raw_result);
-              
+
             // Note the position of the internally-stored Holder,
             // for the sake of destruction
             const size_t offset = reinterpret_cast<size_t>(holder) -
@@ -58,7 +58,7 @@ struct make_instance_impl
         return raw_result;
     }
 };
-    
+
 
 template <class T, class Holder>
 struct make_instance
@@ -69,7 +69,7 @@ struct make_instance
     {
         return converter::registered<T>::converters.get_class_object();
     }
-    
+
     static inline Holder* construct(void* storage, PyObject* instance, reference_wrapper<T const> x)
     {
         size_t allocated = objects::additional_instance_size<Holder>::value;
@@ -78,7 +78,7 @@ struct make_instance
         return new (aligned_storage) Holder(instance, x);
     }
 };
-  
+
 
 }}} // namespace boost::python::object
 

--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -73,7 +73,7 @@ namespace
               , &SlotPolicy::get_pytype
               );
       }
-      
+
    private:
       static void* convertible(PyObject* obj)
       {
@@ -92,19 +92,19 @@ namespace
 # ifdef _MSC_VER
 #  pragma warning(push)
 #  pragma warning(disable:4244)
-# endif 
+# endif
           new (storage) T( SlotPolicy::extract(intermediate.get()) );
-          
+
 # ifdef _MSC_VER
 #  pragma warning(pop)
-# endif 
+# endif
           // record successful construction
           data->convertible = storage;
       }
   };
 
   // identity_unaryfunc/py_object_identity -- manufacture a unaryfunc
-  // "slot" which just returns its argument. 
+  // "slot" which just returns its argument.
   extern "C" PyObject* identity_unaryfunc(PyObject* x)
   {
       Py_INCREF(x);
@@ -180,7 +180,7 @@ namespace
           return numeric_cast<T>(x);
       }
   };
-  
+
   // A SlotPolicy for extracting unsigned integer types from Python objects
   struct unsigned_int_rvalue_from_python_base
   {
@@ -214,9 +214,9 @@ namespace
               return numeric_cast<T>(result);
           } else {
               // None of PyInt_AsUnsigned*() functions check for negative
-              // overflow, so use PyInt_AS_LONG instead and check if number is
+              // overflow, so use PyInt_AsLong instead and check if number is
               // negative, issuing the exception appropriately.
-              long result = PyInt_AS_LONG(intermediate);
+              long result = PyInt_AsLong(intermediate);
               if (PyErr_Occurred())
                   throw_error_already_set();
               if (result < 0) {
@@ -233,7 +233,7 @@ namespace
 // Checking Python's macro instead of Boost's - we don't seem to get
 // the config right all the time. Furthermore, Python's is defined
 // when long long is absent but __int64 is present.
-  
+
 #ifdef HAVE_LONG_LONG
   // A SlotPolicy for extracting long long types from Python objects
 
@@ -260,7 +260,7 @@ namespace
       }
       static PyTypeObject const* get_pytype() { return &PyLong_Type;}
   };
-  
+
   struct long_long_rvalue_from_python : long_long_rvalue_from_python_base
   {
       static BOOST_PYTHON_LONG_LONG extract(PyObject* intermediate)
@@ -268,13 +268,13 @@ namespace
 #if PY_VERSION_HEX < 0x03000000
           if (PyInt_Check(intermediate))
           {
-              return PyInt_AS_LONG(intermediate);
+              return PyInt_AsLong(intermediate);
           }
           else
 #endif
           {
               BOOST_PYTHON_LONG_LONG result = PyLong_AsLongLong(intermediate);
-              
+
               if (PyErr_Occurred())
                   throw_error_already_set();
 
@@ -290,13 +290,13 @@ namespace
 #if PY_VERSION_HEX < 0x03000000
           if (PyInt_Check(intermediate))
           {
-              return numeric_cast<unsigned BOOST_PYTHON_LONG_LONG>(PyInt_AS_LONG(intermediate));
+              return numeric_cast<unsigned BOOST_PYTHON_LONG_LONG>(PyInt_AsLong(intermediate));
           }
           else
 #endif
           {
               unsigned BOOST_PYTHON_LONG_LONG result = PyLong_AsUnsignedLongLong(intermediate);
-              
+
               if (PyErr_Occurred())
                   throw_error_already_set();
 
@@ -304,7 +304,7 @@ namespace
           }
       }
   };
-#endif 
+#endif
 
   // A SlotPolicy for extracting bool from a Python object
   struct bool_rvalue_from_python
@@ -319,7 +319,7 @@ namespace
           return obj == Py_None || PyInt_Check(obj) ? &py_object_identity : 0;
 #endif
       }
-      
+
       static bool extract(PyObject* intermediate)
       {
           return PyObject_IsTrue(intermediate);
@@ -354,18 +354,18 @@ namespace
           return (PyLong_Check(obj) || PyFloat_Check(obj))
               ? &number_methods->nb_float : 0;
       }
-      
+
       static double extract(PyObject* intermediate)
       {
 #if PY_VERSION_HEX < 0x03000000
           if (PyInt_Check(intermediate))
           {
-              return PyInt_AS_LONG(intermediate);
+              return PyInt_AsLong(intermediate);
           }
           else
 #endif
           {
-              return PyFloat_AS_DOUBLE(intermediate);
+              return PyFloat_AsDouble(intermediate);
           }
       }
       static PyTypeObject const* get_pytype() { return &PyFloat_Type;}
@@ -382,7 +382,7 @@ namespace
       static unaryfunc* get_slot(PyObject* obj)
       {
 #if PY_VERSION_HEX >= 0x03000000
-          return (PyUnicode_Check(obj)) ? &py_unicode_as_string_unaryfunc : 
+          return (PyUnicode_Check(obj)) ? &py_unicode_as_string_unaryfunc :
                   PyBytes_Check(obj) ? &py_object_identity : 0;
 #else
           return (PyString_Check(obj)) ? &obj->ob_type->tp_str : 0;
@@ -390,7 +390,7 @@ namespace
 #endif
       };
 
-      // Remember that this will be used to construct the result object 
+      // Remember that this will be used to construct the result object
 #if PY_VERSION_HEX >= 0x03000000
       static std::string extract(PyObject* intermediate)
       {
@@ -432,7 +432,7 @@ namespace
             : 0;
       };
 
-      // Remember that this will be used to construct the result object 
+      // Remember that this will be used to construct the result object
       static std::wstring extract(PyObject* intermediate)
       {
           // On Windows, with Python >= 3.3, PyObject_Length cannot be used to get
@@ -470,7 +470,7 @@ namespace
       }
       static PyTypeObject const* get_pytype() { return &PyUnicode_Type;}
   };
-#endif 
+#endif
 
   struct complex_rvalue_from_python
   {
@@ -481,7 +481,7 @@ namespace
           else
               return float_rvalue_from_python::get_slot(obj);
       }
-      
+
       static std::complex<double> extract(PyObject* intermediate)
       {
           if (PyComplex_Check(intermediate))
@@ -493,17 +493,17 @@ namespace
 #if PY_VERSION_HEX < 0x03000000
           else if (PyInt_Check(intermediate))
           {
-              return PyInt_AS_LONG(intermediate);
+              return PyInt_AsLong(intermediate);
           }
 #endif
           else
           {
-              return PyFloat_AS_DOUBLE(intermediate);
+              return PyFloat_AsDouble(intermediate);
           }
       }
       static PyTypeObject const* get_pytype() { return &PyComplex_Type;}
   };
-} 
+}
 
 BOOST_PYTHON_DECL PyObject* do_return_to_python(char x)
 {
@@ -513,7 +513,7 @@ BOOST_PYTHON_DECL PyObject* do_return_to_python(char x)
     return PyString_FromStringAndSize(&x, 1);
 #endif
 }
-  
+
 BOOST_PYTHON_DECL PyObject* do_return_to_python(char const* x)
 {
 #if PY_VERSION_HEX >= 0x03000000
@@ -522,17 +522,17 @@ BOOST_PYTHON_DECL PyObject* do_return_to_python(char const* x)
     return x ? PyString_FromString(x) : boost::python::detail::none();
 #endif
 }
-  
+
 BOOST_PYTHON_DECL PyObject* do_return_to_python(PyObject* x)
 {
     return x ? x : boost::python::detail::none();
 }
-  
+
 BOOST_PYTHON_DECL PyObject* do_arg_to_python(PyObject* x)
 {
     if (x == 0)
         return boost::python::detail::none();
-      
+
     Py_INCREF(x);
     return x;
 }
@@ -545,7 +545,7 @@ BOOST_PYTHON_DECL PyObject* do_arg_to_python(PyObject* x)
 
 #define REGISTER_INT_CONVERTERS2(U)             \
         REGISTER_INT_CONVERTERS(signed, U);     \
-        REGISTER_INT_CONVERTERS(unsigned, U)  
+        REGISTER_INT_CONVERTERS(unsigned, U)
 
 void initialize_builtin_converters()
 {
@@ -557,23 +557,23 @@ void initialize_builtin_converters()
     REGISTER_INT_CONVERTERS2(short);
     REGISTER_INT_CONVERTERS2(int);
     REGISTER_INT_CONVERTERS2(long);
-    
+
 // using Python's macro instead of Boost's - we don't seem to get the
 // config right all the time.
 # ifdef HAVE_LONG_LONG
     slot_rvalue_from_python<signed BOOST_PYTHON_LONG_LONG,long_long_rvalue_from_python>();
     slot_rvalue_from_python<unsigned BOOST_PYTHON_LONG_LONG,unsigned_long_long_rvalue_from_python>();
 # endif
-        
+
     // floating types
     slot_rvalue_from_python<float,float_rvalue_from_python>();
     slot_rvalue_from_python<double,float_rvalue_from_python>();
     slot_rvalue_from_python<long double,float_rvalue_from_python>();
-    
+
     slot_rvalue_from_python<std::complex<float>,complex_rvalue_from_python>();
     slot_rvalue_from_python<std::complex<double>,complex_rvalue_from_python>();
     slot_rvalue_from_python<std::complex<long double>,complex_rvalue_from_python>();
-    
+
     // Add an lvalue converter for char which gets us char const*
 #if PY_VERSION_HEX < 0x03000000
     registry::insert(convert_to_cstring,type_id<char>(),&converter::wrap_pytype<&PyString_Type>::get_pytype);
@@ -584,7 +584,7 @@ void initialize_builtin_converters()
     // Register by-value converters to std::string, std::wstring
 #if defined(Py_USING_UNICODE) && !defined(BOOST_NO_STD_WSTRING)
     slot_rvalue_from_python<std::wstring, wstring_rvalue_from_python>();
-# endif 
+# endif
     slot_rvalue_from_python<std::string, string_rvalue_from_python>();
 
 }

--- a/src/object/class.cpp
+++ b/src/object/class.cpp
@@ -35,7 +35,7 @@ namespace self_ns
 {
   self_t self;
 }
-# endif 
+# endif
 
 instance_holder::instance_holder()
     : m_next(0)
@@ -105,7 +105,7 @@ extern "C"
       return 0;
   }
 
- 
+
   static PyObject *
   static_data_descr_get(PyObject *self, PyObject * /*obj*/, PyObject * /*type*/)
   {
@@ -216,7 +216,7 @@ namespace objects
       }
       return upcast<PyObject>(&static_data_object);
   }
-}  
+}
 
 extern "C"
 {
@@ -238,7 +238,7 @@ extern "C"
         PyObject* a = _PyType_Lookup(downcast<PyTypeObject>(obj), name);
 
         // a is a borrowed reference or 0
-        
+
         // If we found a static data descriptor, call it directly to
         // force it to set the static data member
         if (a != 0 && PyObject_IsInstance(a, objects::static_data()))
@@ -336,7 +336,7 @@ namespace objects
               p->~instance_holder();
               instance_holder::deallocate(inst, dynamic_cast<void*>(p));
           }
-        
+
           // Python 2.2.1 won't add weak references automatically when
           // tp_itemsize > 0, so we need to manage that
           // ourselves. Accordingly, we also have to clean up the
@@ -345,7 +345,7 @@ namespace objects
             PyObject_ClearWeakRefs(inst);
 
           Py_XDECREF(kill_me->dict);
-          
+
           Py_TYPE(inst)->tp_free(inst);
       }
 
@@ -356,16 +356,16 @@ namespace objects
           PyObject* d = type_->tp_dict;
           PyObject* instance_size_obj = PyObject_GetAttrString(d, const_cast<char*>("__instance_size__"));
 
-          ssize_t instance_size = instance_size_obj ? 
+          ssize_t instance_size = instance_size_obj ?
 #if PY_VERSION_HEX >= 0x03000000
               PyLong_AsSsize_t(instance_size_obj) : 0;
 #else
               PyInt_AsLong(instance_size_obj) : 0;
 #endif
-          
+
           if (instance_size < 0)
               instance_size = 0;
-          
+
           PyErr_Clear(); // Clear any errors that may have occurred.
 
           instance<>* result = (instance<>*)type_->tp_alloc(type_, instance_size);
@@ -387,7 +387,7 @@ namespace objects
               inst->dict = PyDict_New();
           return python::xincref(inst->dict);
       }
-    
+
       static int instance_set_dict(PyObject* op, PyObject* dict, void*)
       {
           instance<>* inst = downcast<instance<> >(op);
@@ -404,7 +404,7 @@ namespace objects
       {0, 0, 0, 0, 0}
   };
 
-  
+
   static PyMemberDef instance_members[] = {
       {const_cast<char*>("__weakref__"), T_OBJECT, offsetof(instance<>, weakrefs), 0, 0},
       {0, 0, 0, 0, 0}
@@ -481,7 +481,7 @@ namespace objects
       if (!Py_TYPE(Py_TYPE(inst)) ||
               !PyType_IsSubtype(Py_TYPE(Py_TYPE(inst)), &class_metatype_object))
           return 0;
-    
+
       instance<>* self = reinterpret_cast<instance<>*>(inst);
 
       for (instance_holder* match = self->objects; match != 0; match = match->next())
@@ -545,7 +545,7 @@ namespace objects
     new_class(char const* name, std::size_t num_types, type_info const* const types, char const* doc)
     {
       assert(num_types >= 1);
-      
+
       // Build a tuple of the base Python type objects. If no bases
       // were declared, we'll use our class_type() as the single base
       // class.
@@ -555,22 +555,22 @@ namespace objects
       for (ssize_t i = 1; i <= num_bases; ++i)
       {
           type_handle c = (i >= static_cast<ssize_t>(num_types)) ? class_type() : get_class(types[i]);
-          // PyTuple_SET_ITEM steals this reference
-          PyTuple_SET_ITEM(bases.get(), static_cast<ssize_t>(i - 1), upcast<PyObject>(c.release()));
+          // PyTuple_SetItem steals this reference
+          PyTuple_SetItem(bases.get(), static_cast<ssize_t>(i - 1), upcast<PyObject>(c.release()));
       }
 
       // Call the class metatype to create a new class
       dict d;
-   
+
       object m = module_prefix();
       if (m) d["__module__"] = m;
 
       if (doc != 0)
           d["__doc__"] = doc;
-      
+
       object result = object(class_metatype())(name, bases, d);
       assert(PyType_IsSubtype(Py_TYPE(result.ptr()), &PyType_Type));
-      
+
       if (scope().ptr() != Py_None)
           scope().attr(name) = result;
 
@@ -581,7 +581,7 @@ namespace objects
       return result;
     }
   }
-  
+
   class_base::class_base(
       char const* name, std::size_t num_types, type_info const* const types, char const* doc)
       : object(new_class(name, num_types, types, doc))
@@ -598,24 +598,24 @@ namespace objects
   {
       converter::registration& dst_converters
           = const_cast<converter::registration&>(converter::registry::lookup(dst));
-      
+
       converter::registration const& src_converters = converter::registry::lookup(src);
 
       dst_converters.m_class_object = src_converters.m_class_object;
   }
-  
+
   void class_base::set_instance_size(std::size_t instance_size)
   {
       this->attr("__instance_size__") = instance_size;
   }
-  
+
   void class_base::add_property(
     char const* name, object const& fget, char const* docstr)
   {
       object property(
           (python::detail::new_reference)
           PyObject_CallFunction((PyObject*)&PyProperty_Type, const_cast<char*>("Osss"), fget.ptr(), (char*)NULL, (char*)NULL, docstr));
-      
+
       this->setattr(name, property);
   }
 
@@ -625,17 +625,17 @@ namespace objects
       object property(
           (python::detail::new_reference)
           PyObject_CallFunction((PyObject*)&PyProperty_Type, const_cast<char*>("OOss"), fget.ptr(), fset.ptr(), (char*)NULL, docstr));
-      
+
       this->setattr(name, property);
   }
 
   void class_base::add_static_property(char const* name, object const& fget)
   {
       object property(
-          (python::detail::new_reference) 
+          (python::detail::new_reference)
           PyObject_CallFunction(static_data(), const_cast<char*>("O"), fget.ptr())
           );
-      
+
       this->setattr(name, property);
   }
 
@@ -644,7 +644,7 @@ namespace objects
       object property(
           (python::detail::new_reference)
           PyObject_CallFunction(static_data(), const_cast<char*>("OO"), fget.ptr(), fset.ptr()));
-      
+
       this->setattr(name, property);
   }
 
@@ -667,7 +667,7 @@ namespace objects
                           "This class cannot be instantiated from Python\n")
     };
   }
-  
+
   void class_base::def_no_init()
   {
       handle<> f(::PyCFunction_New(&no_init_def, 0));
@@ -677,7 +677,7 @@ namespace objects
   void class_base::enable_pickling_(bool getstate_manages_dict)
   {
       setattr("__safe_for_unpickling__", object(true));
-      
+
       if (getstate_manages_dict)
       {
           setattr("__getstate_manages_dict__", object(true));
@@ -696,12 +696,12 @@ namespace objects
           , const_cast<char*>("staticmethod expects callable object; got an object of type %s, which is not callable")
             , Py_TYPE(callable)->tp_name
             );
-        
+
         throw_error_already_set();
         return 0;
     }
   }
-  
+
   void class_base::make_method_static(const char * method_name)
   {
       PyTypeObject* self = downcast<PyTypeObject>(this->ptr());
@@ -728,9 +728,9 @@ void* instance_holder::allocate(PyObject* self_, std::size_t holder_offset, std:
 {
     assert(PyType_IsSubtype(Py_TYPE(Py_TYPE(self_)), &class_metatype_object));
     objects::instance<>* self = (objects::instance<>*)self_;
-    
+
     int total_size_needed = holder_offset + holder_size + alignment - 1;
-    
+
     if (-Py_SIZE(self) >= total_size_needed)
     {
         // holder_offset should at least point into the variable-sized part

--- a/src/object/enum.cpp
+++ b/src/object/enum.cpp
@@ -52,7 +52,7 @@ extern "C"
 #if PY_VERSION_HEX >= 0x03000000
                 PyUnicode_FromFormat("%S.%s(%ld)", mod, self_->ob_type->tp_name, PyLong_AsLong(self_));
 #else
-                PyString_FromFormat("%s.%s(%ld)", PyString_AsString(mod), self_->ob_type->tp_name, PyInt_AS_LONG(self_));
+                PyString_FromFormat("%s.%s(%ld)", PyString_AsString(mod), self_->ob_type->tp_name, PyInt_AsLong(self_));
 #endif
         }
         else
@@ -65,7 +65,7 @@ extern "C"
 #if PY_VERSION_HEX >= 0x03000000
                 PyUnicode_FromFormat("%S.%s.%S", mod, self_->ob_type->tp_name, name);
 #else
-                PyString_FromFormat("%s.%s.%s", 
+                PyString_FromFormat("%s.%s.%s",
                         PyString_AsString(mod), self_->ob_type->tp_name, PyString_AsString(name));
 #endif
         }

--- a/src/object/iterator.cpp
+++ b/src/object/iterator.cpp
@@ -8,13 +8,13 @@
 #include <boost/bind/bind.hpp>
 #include <boost/mpl/vector/vector10.hpp>
 
-namespace boost { namespace python { namespace objects { 
+namespace boost { namespace python { namespace objects {
 
 namespace
 {
   PyObject* identity(PyObject* args_, PyObject*)
   {
-      PyObject* x = PyTuple_GET_ITEM(args_,0);
+      PyObject* x = PyTuple_GetItem(args_,0);
       Py_INCREF(x);
       return x;
   }

--- a/src/object/life_support.cpp
+++ b/src/object/life_support.cpp
@@ -6,7 +6,7 @@
 #include <boost/python/detail/none.hpp>
 #include <boost/python/refcount.hpp>
 
-namespace boost { namespace python { namespace objects { 
+namespace boost { namespace python { namespace objects {
 
 struct life_support
 {
@@ -30,7 +30,7 @@ extern "C"
         Py_XDECREF(((life_support*)self)->patient);
         ((life_support*)self)->patient = 0;
         // Let the weak reference die. This probably kills us.
-        Py_XDECREF(PyTuple_GET_ITEM(arg, 0));
+        Py_XDECREF(PyTuple_GetItem(arg, 0));
         return ::boost::python::detail::none();
     }
 }
@@ -90,19 +90,19 @@ PyObject* make_nurse_and_patient(PyObject* nurse, PyObject* patient)
 {
     if (nurse == Py_None || nurse == patient)
         return nurse;
-    
+
     if (Py_TYPE(&life_support_type) == 0)
     {
         Py_SET_TYPE(&life_support_type, &PyType_Type);
         PyType_Ready(&life_support_type);
     }
-    
+
     life_support* system = PyObject_New(life_support, &life_support_type);
     if (!system)
         return 0;
 
     system->patient = 0;
-    
+
     // We're going to leak this reference, but don't worry; the
     // life_support system decrements it when the nurse dies.
     PyObject* weakref = PyWeakref_NewRef(nurse, (PyObject*)system);
@@ -112,7 +112,7 @@ PyObject* make_nurse_and_patient(PyObject* nurse, PyObject* patient)
     Py_DECREF(system);
     if (!weakref)
         return 0;
-    
+
     system->patient = patient;
     Py_XINCREF(patient); // hang on to the patient until death
     return weakref;


### PR DESCRIPTION
To allow building multi-version Python 3 extensions.

The replaced methods are error-checking variants.

Ref: https://github.com/boostorg/python/issues/221