### PR TITLE
Use a greater BOOST_PYTHON_MAX_ARITY (31)

### DIFF
--- a/include/boost/python/detail/preprocessor.hpp
+++ b/include/boost/python/detail/preprocessor.hpp
@@ -26,7 +26,7 @@
 # endif
 
 # ifndef BOOST_PYTHON_MAX_ARITY
-#  define BOOST_PYTHON_MAX_ARITY 15
+#  define BOOST_PYTHON_MAX_ARITY 31
 # endif
 
 # ifndef BOOST_PYTHON_MAX_BASES


### PR DESCRIPTION
I am working on a project that requires more than 15 arguments at many places (sometimes up to 24). I know this isn't ideal but that would really help us as otherwise we have to change our APIs to group some args which is even less ideal IMHO..

If there would be no limitation that would be even better but I m not experienced enough to enter/start this work so I propose this humble / simple patch ..

Thanks.