### PR TITLE
Handle NULL from call to PyLong_Type

### DIFF
--- a/include/boost/python/long.hpp
+++ b/include/boost/python/long.hpp
@@ -24,8 +24,8 @@ namespace detail
       BOOST_PYTHON_FORWARD_OBJECT_CONSTRUCTORS(long_base, object)
           
    private:
-      static detail::new_non_null_reference call(object const&);
-      static detail::new_non_null_reference call(object const&, object const&);
+      static detail::new_reference call(object const&);
+      static detail::new_reference call(object const&, object const&);
   };
 }
 

--- a/src/long.cpp
+++ b/src/long.cpp
@@ -6,16 +6,16 @@
 
 namespace boost { namespace python { namespace detail {
 
-new_non_null_reference long_base::call(object const& arg_)
+new_reference long_base::call(object const& arg_)
 {
-    return (detail::new_non_null_reference)PyObject_CallFunction(
+    return (detail::new_reference)PyObject_CallFunction(
         (PyObject*)&PyLong_Type, const_cast<char*>("(O)"), 
         arg_.ptr());
 }
 
-new_non_null_reference long_base::call(object const& arg_, object const& base)
+new_reference long_base::call(object const& arg_, object const& base)
 {
-    return (detail::new_non_null_reference)PyObject_CallFunction(
+    return (detail::new_reference)PyObject_CallFunction(
         (PyObject*)&PyLong_Type, const_cast<char*>("(OO)"), 
         arg_.ptr(), base.ptr());
 }


### PR DESCRIPTION
PyLong_Type raises an exception if the argument is not convertible to
long, therefore, this has to be handled as new_reference and not
new_non_null_reference, otherwise a segfault will occur.