### PR TITLE
Use python macros to permit alternate pythons (start pypy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,26 @@ jobs:
       env: CXX=clang++ PYTHON=python3 CXXFLAGS=-std=c++98
     - os: linux
       env: CXX=clang++ PYTHON=python3 CXXFLAGS=-std=c++11
+    - os: linux
+      env: CXX=g++ PYTHON=pypy3 CXXFLAGS=-std=c++11
     - os: osx
       env: CXX=clang++ PYTHON=python CXXFLAGS=-std=c++11
     - env: PYTHON=python DOC=1
   allow_failures:
+    - os: linux
+      env: CXX=g++ PYTHON=pypy3 CXXFLAGS=-std=c++11
     - os: osx
 
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - pypy
     packages:
     - gcc
     - g++
     - clang
+    - pypy3-dev
     - python3-pip
     - python-numpy
     - python-sphinx

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -104,14 +104,22 @@ object BOOST_PYTHON_DECL exec_file(char const *filename, object global, object l
   if (local.is_none()) local = global;
   // should be 'char const *' but older python versions don't use 'const' yet.
   char *f = const_cast<char *>(filename);
-  // Let python open the file to avoid potential binary incompatibilities.
-#if PY_VERSION_HEX >= 0x03040000
-  FILE *fs = _Py_fopen(f, "r");
-#elif PY_VERSION_HEX >= 0x03000000
+#if PY_VERSION_HEX >= 0x03010000
+  // Let python manage any UTF bits to avoid potential incompatibilities.
   PyObject *fo = Py_BuildValue("s", f);
-  FILE *fs = _Py_fopen(fo, "r");
+  PyObject *fb = Py_None;
+  PyUnicode_FSConverter(fo, &fb);
+  f = PyBytes_AsString(fb);
+  FILE *fs = fopen(f, "r");
+  Py_DECREF(fo);
+  Py_DECREF(fb);
+#elif PY_VERSION_HEX >= 0x03000000
+  // Let python open the file to avoid potential binary incompatibilities.
+  PyObject *fo = Py_BuildValue("s", f);
+  FILE *fs = _Py_fopen(fo, "r"); // Private CPython API
   Py_DECREF(fo);
 #else
+  // Let python open the file to avoid potential binary incompatibilities.
   PyObject *pyfile = PyFile_FromString(f, const_cast<char*>("r"));
   if (!pyfile) throw std::invalid_argument(std::string(f) + " : no such file");
   python::handle<> file(pyfile);

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -25,7 +25,7 @@ namespace detail
             
               if (
                   PyMethod_Check(m.get())
-                  && ((PyMethodObject*)m.get())->im_self == this->m_self
+                  && PyMethod_GET_SELF(m.get()) == this->m_self
                   && class_object->tp_dict != 0
               )
               {
@@ -34,7 +34,7 @@ namespace detail
 
 
               }
-              if (borrowed_f != ((PyMethodObject*)m.get())->im_func)
+              if (borrowed_f != PyMethod_GET_FUNCTION(m.get()))
                   return override(m);
           }
       }


### PR DESCRIPTION
Resolves https://svn.boost.org/trac10/ticket/4125

This change uses the official python macros for object access.  This should have no impact on existing CPython usage, but will permit alternate pythons (such as pypy) to utilize boost.