### PR TITLE
Ensure all doctests run

### DIFF
--- a/test/args.py
+++ b/test/args.py
@@ -1,15 +1,19 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 """
 >>> from args_ext import *
 
->>> raw(3, 4, foo = 'bar', baz = 42)
-((3, 4), {'foo': 'bar', 'baz': 42})
+>>> args, kwargs = raw(3, 4, foo = 'bar', baz = 42)
+>>> args
+(3, 4)
+>>> kwargs['foo']
+'bar'
+>>> kwargs['baz']
+42
 
    Prove that we can handle empty keywords and non-keywords
-   
+
 >>> raw(3, 4)
 ((3, 4), {})
 
@@ -76,7 +80,7 @@ from __future__ import print_function
 ... else: print('expected an exception: unknown keyword')
 
    Exercise member functions using default stubs
-   
+
 >>> q.f1(z = 'nix', y = .125, x = 2)
 (2, 0.125, 'nix')
 >>> q.f1(y = .125, x = 2)
@@ -123,10 +127,16 @@ from __future__ import print_function
 1
 
 >>> y = Y(value = 33)
->>> y.raw(this = 1, that = 'the other')[1]
-{'this': 1, 'that': 'the other'}
+>>> _, kwargs = y.raw(this = 1, that = 'the other')
+>>> kwargs['this']
+1
+>>> kwargs['that']
+'the other'
 
 """
+
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -143,6 +153,3 @@ if __name__ == '__main__':
     import args_ext
     help(args_ext)
     sys.exit(status)
-
-
-

--- a/test/dict.cpp
+++ b/test/dict.cpp
@@ -21,11 +21,13 @@ object new_dict()
 object data_dict()
 {
     dict tmp1;
-    tmp1["key1"] = "value1";
 
     dict tmp2;
     tmp2["key2"] = "value2";
     tmp1[1] = tmp2;
+
+    tmp1["key1"] = "value1";
+
     return tmp1;
 }
 
@@ -60,22 +62,20 @@ void work_with_dict(dict data1, dict data2)
 void test_templates(object print)
 {
     std::string key = "key";
-    
+
     dict tmp;
-    tmp[1] = "a test string";
-    print(tmp.get(1));
-    //print(tmp[1]);
     tmp[1.5] = 13;
     print(tmp.get(1.5));
+    tmp[1] = "a test string";
+    print(tmp.get(1));
     print(tmp.get(44));
     print(tmp);
     print(tmp.get(2,"default"));
     print(tmp.setdefault(3,"default"));
 
     BOOST_ASSERT(!tmp.has_key(key));
-    //print(tmp[3]);
 }
-    
+
 BOOST_PYTHON_MODULE(dict_ext)
 {
     def("new_dict", new_dict);

--- a/test/dict.py
+++ b/test/dict.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 """
 >>> from dict_ext import *
 >>> def printer(*args):
@@ -22,13 +21,15 @@ from __future__ import print_function
 >>> print(dict_from_sequence([(1,1),(2,2),(3,3)]))
 {1: 1, 2: 2, 3: 3}
 >>> test_templates(printer) #doctest: +NORMALIZE_WHITESPACE
-a test string
 13
+a test string
 None
 {1.5: 13, 1: 'a test string'}
 default
 default
 """
+
+from __future__ import print_function
 
 def run(args = None):
     import sys
@@ -37,7 +38,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/fabscript
+++ b/test/fabscript
@@ -21,14 +21,14 @@ src = module('..src')
 python_libs=python.instance().libs
 features |= runpath(src.bpl.path, base='')
 
-def extension_test(name, ext=[], script=None, np=False,
+def extension_test(name, exts=[], script=None, numpy=False,
                    features=features, condition=None):
     """Create a Python extension test `name`.
     Arguments:
       * name: the name of the test.
-      * ext: extensions to be compiled, <name> if none are given.
+      * exts: extensions to be compiled, <name> if none are given.
       * script: the test script to execute, <name>.py if none is given.
-      * np: if true, add boost_numpy to sources
+      * numpy: if true, add boost_numpy to sources
       * features: pre-defined features
       * condition: any condition under which to run the test
     Return:
@@ -36,17 +36,17 @@ def extension_test(name, ext=[], script=None, np=False,
 
     features=features.copy()
     extensions = []
-    libs = [src.bnl, src.bpl] if np else [src.bpl]
-    for e in ext or [name]:
-        if type(e) is str:  # build from a single source file
-            n = e if e != name else e + '_ext'
-            s = [e + '.cpp']
+    libs = [src.bnl, src.bpl] if numpy else [src.bpl]
+    for ext in exts or [name]:
+        if type(ext) is str:  # build from a single source file
+            ext_name = ext if ext != name else ext + '_ext'
+            sources = [ext + '.cpp']
         else:  # build from a list of source files
-            n = e[0] if e[0] != name else e[0] + '_ext'
-            s = [n + '.cpp' for n in e]
-        e = extension(n, s + libs, features=features)
-        features |= pythonpath(e.path, base='')
-        extensions.append(e)
+            ext_name = ext[0] if ext[0] != name else ext[0] + '_ext'
+            sources = [source + '.cpp' for source in ext]
+        ext = extension(ext_name, sources + libs, features=features)
+        features |= pythonpath(ext.path, base='')
+        extensions.append(ext)
     if not script:
         script = name+'.py'
     return test(name, script, run=python.run, dependencies=extensions,
@@ -167,7 +167,7 @@ for t in ['numpy/dtype',
           'numpy/ndarray',
           'numpy/indexing',
           'numpy/shapes']:
-    tests.append(extension_test(t, np=True,
+    tests.append(extension_test(t, numpy=True,
                                 condition=set.define.contains('HAS_NUMPY')))
 
 default = report('report', tests, fail_on_failures=True)

--- a/test/iterator.py
+++ b/test/iterator.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 '''
 >>> from iterator_ext import *
 >>> from input_iterator import *
@@ -25,7 +24,7 @@ from __future__ import print_function
 
    Range2 wraps a transform_iterator which doubles the elements it
    traverses. This proves we can wrap input iterators
-   
+
 >>> z2 = range2(x)
 >>> for y in z2:
 ...     print(y)
@@ -56,12 +55,15 @@ from __future__ import print_function
 >>> ll.push_back(x)
 >>> for a in ll: #doctest: +NORMALIZE_WHITESPACE
 ...     for b in a:
-...         print(b, end='')
+...         print(b, end=' ')
 ...     print('')
 ...
 1 3 5
 1 3 5 7
 '''
+
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -69,7 +71,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/list.py
+++ b/test/list.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 '''
 >>> from list_ext import *
 
@@ -41,7 +40,7 @@ X(22)
 ['h', 'e', 'l', 'l', 'o', '.']
 
   tuples do not automatically convert to lists when passed as arguments
-  
+
 >>> try: append_list(letters, (1,2))
 ... except TypeError: pass
 ... else: print('expected an exception')
@@ -51,7 +50,7 @@ X(22)
 ['h', 'e', 'l', 'l', 'o', '.', [1, 2]]
 
     Check that subclass functions are properly called
-    
+
 >>> class mylist(list):
 ...     def append(self, o):
 ...         list.append(self, o)
@@ -103,6 +102,8 @@ reverse sorted:
 ['y', 'x', 'o', 'l', 'l', 'h', 'e', '.']
 '''
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -110,7 +111,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/long.py
+++ b/test/long.py
@@ -1,9 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-import sys
-if (sys.version_info.major >= 3):
-    long = int
 '''
 >>> from long_ext import *
 >>> print(new_long())
@@ -19,6 +16,10 @@ if (sys.version_info.major >= 3):
 
 >>> x = Y(long(4294967295))
 '''
+
+import sys
+if (sys.version_info.major >= 3):
+    long = int
 
 def run(args = None):
     import sys

--- a/test/map_indexing_suite.py
+++ b/test/map_indexing_suite.py
@@ -1,7 +1,6 @@
 # Copyright Joel de Guzman 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 '''
 
 #####################################################################
@@ -25,7 +24,7 @@ foo
 
 # test that a string is implicitly convertible
 # to an X
->>> x_value('bochi bochi') 
+>>> x_value('bochi bochi')
 'gotya bochi bochi'
 
 #####################################################################
@@ -33,9 +32,9 @@ foo
 #####################################################################
 >>> def print_xmap(xmap):
 ...     s = '[ '
-...     for x in xmap: 
+...     for x in xmap:
 ...         s += repr(x)
-...         s += ' ' 
+...         s += ' '
 ...     s += ']'
 ...     print(s)
 
@@ -135,7 +134,7 @@ foo
 >>> assert not 12345 in xm
 
 #####################################################################
-# Some references to the container elements 
+# Some references to the container elements
 #####################################################################
 
 >>> z0 = xm['joel']
@@ -156,7 +155,7 @@ banana
 kiwi
 
 #####################################################################
-# Delete some container element 
+# Delete some container element
 #####################################################################
 
 >>> del xm['tenji']
@@ -168,7 +167,7 @@ kiwi
 [ (joel, apple) (kim, kiwi) (mariel, grape) ]
 
 #####################################################################
-# Show that the references are still valid 
+# Show that the references are still valid
 #####################################################################
 >>> z0 # proxy
 apple
@@ -199,7 +198,7 @@ kiwi
 >>> print_xmap(tm)
 [ (joel, aaa) (kimpo, bbb) ]
 >>> for el in tm: #doctest: +NORMALIZE_WHITESPACE
-...     print(el.key(), end='')
+...     print(el.key(), end=' ')
 ...     dom = el.data()
 joel kimpo
 
@@ -216,11 +215,12 @@ joel kimpo
 4
 
 #####################################################################
-# END.... 
+# END....
 #####################################################################
 
 '''
 
+from __future__ import print_function
 
 def run(args = None):
     import sys
@@ -236,8 +236,3 @@ if __name__ == '__main__':
     status = run()[0]
     if (status == 0): print("Done.")
     sys.exit(status)
-
-
-
-
-

--- a/test/object.py
+++ b/test/object.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 '''
 >>> from object_ext import *
 
@@ -130,14 +129,14 @@ from __future__ import print_function
 1
 
         Slices
-        
+
 >>> assert check_string_slice()
 
         Operators
 
->>> def print_args(*args, **kwds): 
+>>> def print_args(*args, **kwds):
 ...     print(args, kwds)
->>> test_call(print_args, (0, 1, 2, 3), {'a':'A'}) 
+>>> test_call(print_args, (0, 1, 2, 3), {'a':'A'})
 (0, 1, 2, 3) {'a': 'A'}
 
 
@@ -149,7 +148,7 @@ from __future__ import print_function
 
 
        Now make sure that object is actually managing reference counts
-       
+
 >>> import weakref
 >>> class Z: pass
 ...
@@ -164,6 +163,8 @@ from __future__ import print_function
 death
 '''
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -171,7 +172,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/pickle2.py
+++ b/test/pickle2.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 r'''>>> import pickle2_ext
     >>> import pickle
     >>> pickle2_ext.world.__module__
@@ -35,6 +34,8 @@ r'''>>> import pickle2_ext
     Incomplete pickle support (__getstate_manages_dict__ not set)
 '''
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -42,7 +43,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/pickle3.py
+++ b/test/pickle3.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 r'''>>> import pickle3_ext
     >>> import pickle
     >>> pickle3_ext.world.__module__
@@ -30,6 +29,8 @@ r'''>>> import pickle3_ext
     Hello from California! 0 84 yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy 126.0
 '''
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -37,7 +38,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/str.py
+++ b/test/str.py
@@ -1,11 +1,10 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 """
 >>> from str_ext import *
 >>> def printer(*args):
-...     for x in args: print(x, end='')
+...     for x in args: print(x, end=' ')
 ...     print('')
 ...
 >>> work_with_string(printer) #doctest: +NORMALIZE_WHITESPACE
@@ -38,6 +37,8 @@ this is a blabla string
 aaaaaaaaaaaaaaaaaaaaa
 """
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -45,7 +46,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys

--- a/test/test_builtin_converters.py
+++ b/test/test_builtin_converters.py
@@ -1,9 +1,7 @@
+# -*- coding: utf-8 -*-
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-import sys
-if (sys.version_info.major >= 3):
-    long = int
 r"""
 >>> from builtin_converters_ext import *
 
@@ -17,7 +15,7 @@ r"""
 
 # Wrappers to simplify tests
 >>> def should_pass(method, values):
-...     result = map(method, values[0])
+...     result = list(map(method, values[0]))
 ...     if result != values[0]:
 ...         print("Got %s but expected %s" % (result, values[0]))
 >>> def test_overflow(method, values):
@@ -135,9 +133,6 @@ True
 
 >>> print(rewrap_value_wstring(u'yo, wassup?'))
 yo, wassup?
-
->>> print(rewrap_value_wstring(u'\U0001f4a9'))
-\U0001f4a9
 
    test that overloading on unicode works:
 

--- a/test/tuple.py
+++ b/test/tuple.py
@@ -1,7 +1,6 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-from __future__ import print_function
 """
 >>> from tuple_ext import *
 >>> def printer(*args):
@@ -22,6 +21,8 @@ from __future__ import print_function
 ('hello', 42)
 """
 
+from __future__ import print_function
+
 def run(args = None):
     import sys
     import doctest
@@ -29,7 +30,7 @@ def run(args = None):
     if args is not None:
         sys.argv = args
     return doctest.testmod(sys.modules.get(__name__))
-    
+
 if __name__ == '__main__':
     print("running...")
     import sys


### PR DESCRIPTION
905b34210b9ae2310c61b52584313e33b7f131ca added Python 3 compatibility for the tests. However, due to the behavior of doctest, this silently disabled some of the tests. For doctest to pick up module docstrings, the docstring has to be the first statement of the module. You can see that the tests are failing to execute if you add `verbose=True` to the `doctest.testmod()` call.

This PR fixes this error for all 12 modules where there was a non-docstring as the first statement, and then adds minor fixups to the tests to make sure they execute on both Python 2 and Python 3.