### PR TITLE
Fix boost/bind deprecation build warnings

### DIFF
--- a/include/boost/python/exception_translator.hpp
+++ b/include/boost/python/exception_translator.hpp
@@ -7,7 +7,7 @@
 
 # include <boost/python/detail/prefix.hpp>
 
-# include <boost/bind.hpp>
+# include <boost/bind/bind.hpp>
 # include <boost/bind/placeholders.hpp>
 # include <boost/type.hpp>
 # include <boost/python/detail/translate_exception.hpp>
@@ -19,8 +19,13 @@ template <class ExceptionType, class Translate>
 void register_exception_translator(Translate translate, boost::type<ExceptionType>* = 0)
 {
     detail::register_exception_handler(
-        boost::bind<bool>(detail::translate_exception<ExceptionType,Translate>(), _1, _2, translate)
-        );
+        boost::bind<bool>(
+            detail::translate_exception<ExceptionType,Translate>(),
+            boost::placeholders::_1,
+            boost::placeholders::_2,
+            translate
+        )
+    );
 }
 
 }} // namespace boost::python

--- a/include/boost/python/iterator.hpp
+++ b/include/boost/python/iterator.hpp
@@ -22,7 +22,8 @@ works correctly. */
 #  pragma warning(disable: 4180)
 # endif
 
-# include <boost/bind.hpp>
+# include <boost/bind/bind.hpp>
+# include <boost/bind/placeholders.hpp>
 # include <boost/bind/protect.hpp>
 
 namespace boost { namespace python { 
@@ -41,8 +42,8 @@ namespace detail
   )
   {
       return objects::make_iterator_function<Target>(
-          boost::protect(boost::bind(get_start, _1))
-        , boost::protect(boost::bind(get_finish, _1))
+          boost::protect(boost::bind(get_start, boost::placeholders::_1))
+        , boost::protect(boost::bind(get_finish, boost::placeholders::_1))
         , next_policies
       );
   }

--- a/src/object/function.cpp
+++ b/src/object/function.cpp
@@ -21,7 +21,7 @@
 #include <boost/python/detail/none.hpp>
 #include <boost/mpl/vector/vector10.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/src/object/inheritance.cpp
+++ b/src/object/inheritance.cpp
@@ -11,7 +11,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/reverse_graph.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/integer_traits.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
@@ -190,8 +190,8 @@ namespace
           type_index().begin(), type_index().end()
           , boost::make_tuple(type, vertex_t(), dynamic_id_function(0))
           , boost::bind<bool>(std::less<class_id>()
-               , boost::bind<class_id>(select1st<entry>(), _1)
-               , boost::bind<class_id>(select1st<entry>(), _2)));
+               , boost::bind<class_id>(select1st<entry>(), boost::placeholders::_1)
+               , boost::bind<class_id>(select1st<entry>(), boost::placeholders::_2)));
   }
 
   inline index_entry* seek_type(class_id type)

--- a/src/object/iterator.cpp
+++ b/src/object/iterator.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/python/object/iterator_core.hpp>
 #include <boost/python/object/function_object.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mpl/vector/vector10.hpp>
 
 namespace boost { namespace python { namespace objects { 

--- a/test/import_.cpp
+++ b/test/import_.cpp
@@ -6,7 +6,7 @@
 #include <boost/python.hpp>
 
 #include <boost/detail/lightweight_test.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
Including `boost/bind.hpp` is now deprecated in favor of `boost/bind/bind.hpp`, and you must use namespaced placeholders such as `boost::placeholders::_1`.