### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/python/detail/translate_exception.hpp
+++ b/include/boost/python/detail/translate_exception.hpp
@@ -53,7 +53,7 @@ struct translate_exception
         || BOOST_WORKAROUND(__GNUC_PATCHLEVEL__, == 3))
         catch(exception_non_ref& e)
 # else
-        catch(exception_cref e)
+        catch(const exception_cref& e)
 # endif
         {
             translate(e);

--- a/include/boost/python/object/pointer_holder.hpp
+++ b/include/boost/python/object/pointer_holder.hpp
@@ -62,7 +62,7 @@ struct pointer_holder : instance_holder
  private: // types
     
  private: // required holder implementation
-    void* holds(type_info, bool null_ptr_only);
+    void* holds(type_info, bool null_ptr_only) BOOST_OVERRIDE;
     
     template <class T>
     inline void* holds_wrapped(type_info dst_t, wrapper<T>*,T* p)
@@ -96,7 +96,7 @@ struct pointer_holder_back_reference : instance_holder
 #  include BOOST_PP_ITERATE()
 
  private: // required holder implementation
-    void* holds(type_info, bool null_ptr_only);
+    void* holds(type_info, bool null_ptr_only) BOOST_OVERRIDE;
 
  private: // data members
     Pointer m_p;

--- a/include/boost/python/object/py_function.hpp
+++ b/include/boost/python/object/py_function.hpp
@@ -33,17 +33,17 @@ struct caller_py_function_impl : py_function_impl_base
         : m_caller(caller)
     {}
     
-    PyObject* operator()(PyObject* args, PyObject* kw)
+    PyObject* operator()(PyObject* args, PyObject* kw) BOOST_OVERRIDE
     {
         return m_caller(args, kw);
     }
     
-    virtual unsigned min_arity() const
+    unsigned min_arity() const BOOST_OVERRIDE
     {
         return m_caller.min_arity();
     }
     
-    virtual python::detail::py_func_sig_info signature() const
+    python::detail::py_func_sig_info signature() const BOOST_OVERRIDE
     {
         return m_caller.signature();
     }
@@ -59,17 +59,17 @@ struct signature_py_function_impl : py_function_impl_base
         : m_caller(caller)
     {}
     
-    PyObject* operator()(PyObject* args, PyObject* kw)
+    PyObject* operator()(PyObject* args, PyObject* kw) BOOST_OVERRIDE
     {
         return m_caller(args, kw);
     }
     
-    virtual unsigned min_arity() const
+    unsigned min_arity() const BOOST_OVERRIDE
     {
         return mpl::size<Sig>::value - 1;
     }
     
-    virtual python::detail::py_func_sig_info signature() const
+    python::detail::py_func_sig_info signature() const BOOST_OVERRIDE
     {
         python::detail::signature_element const* sig = python::detail::signature<Sig>::elements();
         python::detail::py_func_sig_info res = {sig, sig};
@@ -89,22 +89,22 @@ struct full_py_function_impl : py_function_impl_base
       , m_max_arity(max_arity > min_arity ? max_arity : min_arity)
     {}
     
-    PyObject* operator()(PyObject* args, PyObject* kw)
+    PyObject* operator()(PyObject* args, PyObject* kw) BOOST_OVERRIDE
     {
         return m_caller(args, kw);
     }
     
-    virtual unsigned min_arity() const
+    unsigned min_arity() const BOOST_OVERRIDE
     {
         return m_min_arity;
     }
     
-    virtual unsigned max_arity() const
+    unsigned max_arity() const BOOST_OVERRIDE
     {
         return m_max_arity;
     }
     
-    virtual python::detail::py_func_sig_info signature() const
+    python::detail::py_func_sig_info signature() const BOOST_OVERRIDE
     {
         python::detail::signature_element const* sig = python::detail::signature<Sig>::elements();
         python::detail::py_func_sig_info res = {sig, sig};

--- a/include/boost/python/object/value_holder.hpp
+++ b/include/boost/python/object/value_holder.hpp
@@ -46,7 +46,7 @@ struct value_holder : instance_holder
 #  include BOOST_PP_ITERATE()
 
  private: // required holder implementation
-    void* holds(type_info, bool null_ptr_only);
+    void* holds(type_info, bool null_ptr_only) BOOST_OVERRIDE;
     
     template <class T>
     inline void* holds_wrapped(type_info dst_t, wrapper<T>*,T* p)
@@ -73,7 +73,7 @@ struct value_holder_back_reference : instance_holder
 #  include BOOST_PP_ITERATE()
 
 private: // required holder implementation
-    void* holds(type_info, bool null_ptr_only);
+    void* holds(type_info, bool null_ptr_only) BOOST_OVERRIDE;
 
  private: // data members
     Held m_held;

--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -19,8 +19,8 @@
 #include <boost/python/converter/pytype_function.hpp>
 
 #include <boost/cast.hpp>
-#include <string>
 #include <complex>
+#include <string>
 
 namespace boost { namespace python { namespace converter {
 
@@ -388,7 +388,7 @@ namespace
           return (PyString_Check(obj)) ? &obj->ob_type->tp_str : 0;
 
 #endif
-      };
+      }
 
       // Remember that this will be used to construct the result object 
 #if PY_VERSION_HEX >= 0x03000000
@@ -430,7 +430,7 @@ namespace
 #endif
               ? &py_encode_string
             : 0;
-      };
+      }
 
       // Remember that this will be used to construct the result object 
       static std::wstring extract(PyObject* intermediate)

--- a/src/converter/type_id.cpp
+++ b/src/converter/type_id.cpp
@@ -5,12 +5,12 @@
 
 #include <boost/python/type_id.hpp>
 #include <boost/python/detail/decorated_type_id.hpp>
-#include <utility>
-#include <vector>
 #include <algorithm>
-#include <memory>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #if defined(__QNXNTO__)
 # include <ostream>
@@ -120,7 +120,7 @@ namespace detail
             , std::make_pair(mangled, (char const*)0)
             , compare_first_cstring());
       
-      if (p == demangler.end() || strcmp(p->first, mangled))
+      if (p == demangler.end() || strcmp(p->first, mangled) != 0)
       {
           int status;
           free_mem keeper(


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Fix Clang -Wextra-semi and Clang-tidy bugprone-suspicious-string-compare and misc-throw-by-value-catch-by-reference warnings.