### PR TITLE
Fix deprecated usage of <boost/bind.hpp>

### DIFF
--- a/include/boost/python/exception_translator.hpp
+++ b/include/boost/python/exception_translator.hpp
@@ -7,7 +7,7 @@
 
 # include <boost/python/detail/prefix.hpp>
 
-# include <boost/bind.hpp>
+# include <boost/bind/bind.hpp>
 # include <boost/bind/placeholders.hpp>
 # include <boost/type.hpp>
 # include <boost/python/detail/translate_exception.hpp>
@@ -18,6 +18,7 @@ namespace boost { namespace python {
 template <class ExceptionType, class Translate>
 void register_exception_translator(Translate translate, boost::type<ExceptionType>* = 0)
 {
+    using namespace boost::placeholders;
     detail::register_exception_handler(
         boost::bind<bool>(detail::translate_exception<ExceptionType,Translate>(), _1, _2, translate)
         );

--- a/include/boost/python/iterator.hpp
+++ b/include/boost/python/iterator.hpp
@@ -22,7 +22,7 @@ works correctly. */
 #  pragma warning(disable: 4180)
 # endif
 
-# include <boost/bind.hpp>
+# include <boost/bind/bind.hpp>
 # include <boost/bind/protect.hpp>
 
 namespace boost { namespace python { 
@@ -40,6 +40,7 @@ namespace detail
     , Target&(*)()
   )
   {
+      using namespace boost::placeholders;
       return objects::make_iterator_function<Target>(
           boost::protect(boost::bind(get_start, _1))
         , boost::protect(boost::bind(get_finish, _1))

--- a/src/object/function.cpp
+++ b/src/object/function.cpp
@@ -21,7 +21,7 @@
 #include <boost/python/detail/none.hpp>
 #include <boost/mpl/vector/vector10.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/src/object/inheritance.cpp
+++ b/src/object/inheritance.cpp
@@ -11,7 +11,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/reverse_graph.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/integer_traits.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
@@ -184,6 +184,7 @@ namespace
   // map a type to a position in the index
   inline type_index_t::iterator type_position(class_id type)
   {
+      using namespace boost::placeholders;
       typedef index_entry entry;
       
       return std::lower_bound(

--- a/src/object/iterator.cpp
+++ b/src/object/iterator.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/python/object/iterator_core.hpp>
 #include <boost/python/object/function_object.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mpl/vector/vector10.hpp>
 
 namespace boost { namespace python { namespace objects { 

--- a/test/import_.cpp
+++ b/test/import_.cpp
@@ -6,7 +6,7 @@
 #include <boost/python.hpp>
 
 #include <boost/detail/lightweight_test.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
Using `<boost/bind.hpp>` without `BOOST_BIND_GLOBAL_PLACEHOLDERS` is deprecated.
This patch replaces the usage of `<boost/bind.hpp>` with `<boost/bind/bind.hpp>` and inserts 
`using namespace boost::placeholders` when necessary.