### PR TITLE
Use Py_TYPE() rather than using PyObject.ob_type

### DIFF
--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -154,7 +154,7 @@ namespace
   {
       static unaryfunc* get_slot(PyObject* obj)
       {
-          PyNumberMethods* number_methods = obj->ob_type->tp_as_number;
+          PyNumberMethods* number_methods = Py_TYPE(obj)->tp_as_number;
           if (number_methods == 0)
               return 0;
 
@@ -186,7 +186,7 @@ namespace
   {
       static unaryfunc* get_slot(PyObject* obj)
       {
-          PyNumberMethods* number_methods = obj->ob_type->tp_as_number;
+          PyNumberMethods* number_methods = Py_TYPE(obj)->tp_as_number;
           if (number_methods == 0)
               return 0;
 
@@ -244,7 +244,7 @@ namespace
 #if PY_VERSION_HEX >= 0x03000000
           return PyLong_Check(obj) ? &py_object_identity : 0;
 #else
-          PyNumberMethods* number_methods = obj->ob_type->tp_as_number;
+          PyNumberMethods* number_methods = Py_TYPE(obj)->tp_as_number;
           if (number_methods == 0)
               return 0;
 
@@ -340,7 +340,7 @@ namespace
   {
       static unaryfunc* get_slot(PyObject* obj)
       {
-          PyNumberMethods* number_methods = obj->ob_type->tp_as_number;
+          PyNumberMethods* number_methods = Py_TYPE(obj)->tp_as_number;
           if (number_methods == 0)
               return 0;
 
@@ -385,7 +385,7 @@ namespace
           return (PyUnicode_Check(obj)) ? &py_unicode_as_string_unaryfunc : 
                   PyBytes_Check(obj) ? &py_object_identity : 0;
 #else
-          return (PyString_Check(obj)) ? &obj->ob_type->tp_str : 0;
+          return (PyString_Check(obj)) ? &Py_TYPE(obj)->tp_str : 0;
 
 #endif
       };

--- a/src/converter/from_python.cpp
+++ b/src/converter/from_python.cpp
@@ -101,7 +101,7 @@ BOOST_PYTHON_DECL void* rvalue_from_python_stage2(
                 (
                 "No registered converter was able to produce a C++ rvalue of type %s from this Python object of type %s"
                 , converters.target_type.name()
-                , source->ob_type->tp_name
+                , Py_TYPE(source)->tp_name
                 ));
               
         PyErr_SetObject(PyExc_TypeError, msg.get());
@@ -208,7 +208,7 @@ namespace
               " from this Python object of type %s"
               , ref_type
               , converters.target_type.name()
-              , source->ob_type->tp_name
+              , Py_TYPE(source)->tp_name
               ));
               
       PyErr_SetObject(PyExc_TypeError, msg.get());
@@ -293,7 +293,7 @@ pytype_check(PyTypeObject* type_, PyObject* source)
             PyExc_TypeError
             , "Expecting an object of type %s; got an object of type %s instead"
             , type_->tp_name
-            , source->ob_type->tp_name
+            , Py_TYPE(source)->tp_name
             );
         throw_error_already_set();
     }

--- a/src/numpy/dtype.cpp
+++ b/src/numpy/dtype.cpp
@@ -158,7 +158,7 @@ public:
     }
     else
     {
-      dtype dt(python::detail::borrowed_reference(obj->ob_type));
+      dtype dt(python::detail::borrowed_reference(Py_TYPE(obj)));
       if (equivalent(dt, dtype::get_builtin<T>()))
       {
 	return obj;

--- a/src/object/enum.cpp
+++ b/src/object/enum.cpp
@@ -50,9 +50,9 @@ extern "C"
         {
             return
 #if PY_VERSION_HEX >= 0x03000000
-                PyUnicode_FromFormat("%S.%s(%ld)", mod, self_->ob_type->tp_name, PyLong_AsLong(self_));
+                PyUnicode_FromFormat("%S.%s(%ld)", mod, Py_TYPE(self_)->tp_name, PyLong_AsLong(self_));
 #else
-                PyString_FromFormat("%s.%s(%ld)", PyString_AsString(mod), self_->ob_type->tp_name, PyInt_AS_LONG(self_));
+                PyString_FromFormat("%s.%s(%ld)", PyString_AsString(mod), Py_TYPE(self_)->tp_name, PyInt_AS_LONG(self_));
 #endif
         }
         else
@@ -63,10 +63,10 @@ extern "C"
 
             return
 #if PY_VERSION_HEX >= 0x03000000
-                PyUnicode_FromFormat("%S.%s.%S", mod, self_->ob_type->tp_name, name);
+                PyUnicode_FromFormat("%S.%s.%S", mod, Py_TYPE(self_)->tp_name, name);
 #else
                 PyString_FromFormat("%s.%s.%s", 
-                        PyString_AsString(mod), self_->ob_type->tp_name, PyString_AsString(name));
+                        PyString_AsString(mod), Py_TYPE(self_)->tp_name, PyString_AsString(name));
 #endif
         }
     }

--- a/src/object/life_support.cpp
+++ b/src/object/life_support.cpp
@@ -20,7 +20,7 @@ extern "C"
     life_support_dealloc(PyObject* self)
     {
         Py_XDECREF(((life_support*)self)->patient);
-        self->ob_type->tp_free(self);
+        Py_TYPE(self)->tp_free(self);
     }
 
     static PyObject *

--- a/src/object_protocol.cpp
+++ b/src/object_protocol.cpp
@@ -104,7 +104,7 @@ namespace // slicing code copied directly out of the Python implementation
   apply_slice(PyObject *u, PyObject *v, PyObject *w) /* return u[v:w] */
   {
 #if PY_VERSION_HEX < 0x03000000
-      PyTypeObject *tp = u->ob_type;
+      PyTypeObject *tp = Py_TYPE(u);
       PySequenceMethods *sq = tp->tp_as_sequence;
 
       if (sq && sq->sq_slice && ISINT(v) && ISINT(w)) {
@@ -134,7 +134,7 @@ namespace // slicing code copied directly out of the Python implementation
       /* u[v:w] = x */
   {
 #if PY_VERSION_HEX < 0x03000000
-      PyTypeObject *tp = u->ob_type;
+      PyTypeObject *tp = Py_TYPE(u);
       PySequenceMethods *sq = tp->tp_as_sequence;
 
       if (sq && sq->sq_slice && ISINT(v) && ISINT(w)) {

--- a/test/builtin_converters.cpp
+++ b/test/builtin_converters.cpp
@@ -49,7 +49,7 @@ using boost::python::borrowed;
 // Used to test that arbitrary handle<>s can be returned
 handle<PyTypeObject> get_type(handle<> x)
 {
-    return handle<PyTypeObject>(borrowed(Py_TYPE(x)));
+    return handle<PyTypeObject>(borrowed(Py_TYPE(x.get())));
 }
 
 handle<> return_null_handle()

--- a/test/builtin_converters.cpp
+++ b/test/builtin_converters.cpp
@@ -49,7 +49,7 @@ using boost::python::borrowed;
 // Used to test that arbitrary handle<>s can be returned
 handle<PyTypeObject> get_type(handle<> x)
 {
-    return handle<PyTypeObject>(borrowed(x->ob_type));
+    return handle<PyTypeObject>(borrowed(Py_TYPE(x)));
 }
 
 handle<> return_null_handle()

--- a/test/callbacks.cpp
+++ b/test/callbacks.cpp
@@ -104,7 +104,7 @@ handle<> apply_to_own_type(handle<> x)
 {
     // Tests that we can return handle<> from a callback and that we
     // can pass arbitrary handle<T>.
-    return call<handle<> >(x.get(), type_handle(borrowed(x->ob_type)));
+    return call<handle<> >(x.get(), type_handle(borrowed(Py_TYPE(x))));
 }
 
 object apply_object_object(PyObject* f, object x)

--- a/test/callbacks.cpp
+++ b/test/callbacks.cpp
@@ -104,7 +104,7 @@ handle<> apply_to_own_type(handle<> x)
 {
     // Tests that we can return handle<> from a callback and that we
     // can pass arbitrary handle<T>.
-    return call<handle<> >(x.get(), type_handle(borrowed(Py_TYPE(x))));
+    return call<handle<> >(x.get(), type_handle(borrowed(Py_TYPE(x.get()))));
 }
 
 object apply_object_object(PyObject* f, object x)


### PR DESCRIPTION
Py_TYPE() is available since Python 2.6.