### PR TITLE
New VS2019 version on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
       PYTHON: C:\\Python36-x64
       PYTHON_VERSION: 3.6.x
       PYTHON_ARCH: 64
-      MSVC: 16.7.4
+      MSVC: 16.8.1
       ARCH: x86_64
       BOOST_PREFIX: C:\Libraries\boost_1_73_0
 


### PR DESCRIPTION
Version number needed to be manually rolled to match what is installed in appveyor.