### PR TITLE
Fix compatibility with Python 3.10.0a4: fopen

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -116,7 +116,7 @@ object BOOST_PYTHON_DECL exec_file(char const *filename, object global, object l
 #elif PY_VERSION_HEX >= 0x03000000
   // Let python open the file to avoid potential binary incompatibilities.
   PyObject *fo = Py_BuildValue("s", f);
-  FILE *fs = _Py_fopen(fo, "r"); // Private CPython API
+  FILE *fs = fopen(fo, "r");
   Py_DECREF(fo);
 #else
   // Let python open the file to avoid potential binary incompatibilities.


### PR DESCRIPTION
Replace private _Py_fopen() with public fopen(): private _Py_fopen()
function was removed in 3.10.0a4:
https://bugs.python.org/issue32381