### PR TITLE
Use the /python//numpy target instead of [ numpy.include ] (fixes #361)

### DIFF
--- a/build/Jamfile
+++ b/build/Jamfile
@@ -117,7 +117,7 @@ lib boost_numpy
         <define>BOOST_NUMPY_SOURCE
         [ cond [ python.numpy ] : <library>/python//python_for_extensions ]
         [ unless [ python.numpy ] : <build>no ]
-        <include>$(numpy-include)
+        <library>/python//numpy
         <library>boost_python
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
         -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag


### PR DESCRIPTION
This fixes issue #361 by using the `/python//numpy` target. It however requires the corresponding Boost.Build PR https://github.com/boostorg/build/pull/726 to be merged first.