### PR TITLE
Update call_method.hpp to avoid deprecation issue on PyEval

### DIFF
--- a/include/boost/python/call_method.hpp
+++ b/include/boost/python/call_method.hpp
@@ -59,7 +59,7 @@ call_method(PyObject* self, char const* name
     )
 {
     PyObject* const result = 
-        PyEval_CallMethod(
+        PyObject_CallMethod(
             self
             , const_cast<char*>(name)
             , const_cast<char*>("(" BOOST_PP_REPEAT_1ST(N, BOOST_PYTHON_FIXED, "O") ")")


### PR DESCRIPTION
Was missing from https://github.com/boostorg/python/pull/320
I've tested it on one of my projects with (that patch on) Boost.Python/Boost 1.76.0 and it works well. Without that patch, there is a deprecation error.