### PR TITLE
Fix enum_type_object type on Python 3.11

### DIFF
--- a/src/object/enum.cpp
+++ b/src/object/enum.cpp
@@ -113,7 +113,6 @@ static PyTypeObject enum_type_object = {
 #if PY_VERSION_HEX < 0x03000000
     | Py_TPFLAGS_CHECKTYPES
 #endif
-    | Py_TPFLAGS_HAVE_GC
     | Py_TPFLAGS_BASETYPE,                  /* tp_flags */
     0,                                      /* tp_doc */
     0,                                      /* tp_traverse */


### PR DESCRIPTION
The enum_type_object type inherits from PyLong_Type which is not tracked
by the GC. Instances doesn't have to be tracked by the GC: remove the
Py_TPFLAGS_HAVE_GC flag.

The Python C API documentation says:

    "To create a container type, the tp_flags field of the type object
    must include the Py_TPFLAGS_HAVE_GC and provide an implementation of
    the tp_traverse handler."

https://docs.python.org/dev/c-api/gcsupport.html

The new exception was introduced in Python 3.11 by:
https://github.com/python/cpython/issues/88429