### PR TITLE
dynamic_cast before destructor

### DIFF
--- a/src/object/class.cpp
+++ b/src/object/class.cpp
@@ -333,8 +333,9 @@ namespace objects
           for (instance_holder* p = kill_me->objects, *next; p != 0; p = next)
           {
               next = p->next();
+              void* q = dynamic_cast<void*>(p);
               p->~instance_holder();
-              instance_holder::deallocate(inst, dynamic_cast<void*>(p));
+              instance_holder::deallocate(inst, q);
           }
         
           // Python 2.2.1 won't add weak references automatically when


### PR DESCRIPTION
Call to the destructor ends lifetime of the object, including vptr
used by dynamic_cast.