### PR TITLE
Alignment fixes

### DIFF
--- a/include/boost/python/make_constructor.hpp
+++ b/include/boost/python/make_constructor.hpp
@@ -61,7 +61,8 @@ namespace detail
           typedef objects::pointer_holder<Ptr,value_type> holder;
           typedef objects::instance<holder> instance_t;
 
-          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage), sizeof(holder));
+          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage), sizeof(holder),
+                                          boost::python::detail::alignment_of<holder>::value);
           try {
 #if defined(BOOST_NO_CXX11_SMART_PTR)
               (new (memory) holder(x))->install(this->m_self);

--- a/src/object/class.cpp
+++ b/src/object/class.cpp
@@ -753,10 +753,9 @@ void* instance_holder::allocate(PyObject* self_, std::size_t holder_offset, std:
             throw std::bad_alloc();
 
         const uintptr_t x = reinterpret_cast<uintptr_t>(base_storage) + sizeof(alignment_marker_t);
-        //this has problems for x -> max(void *)
-        //const size_t padding = alignment - ((x + sizeof(alignment_marker_t)) % alignment);
-        //only works for alignments with alignments of powers of 2, but no edge conditions
-        const uintptr_t padding = alignment == 1 ? 0 : ( alignment - (x & (alignment - 1)) );
+        // Padding required to align the start of a data structure is: (alignment - (x % alignment)) % alignment
+        // Since the alignment is a power of two, the formula can be simplified with bitwise AND operator as follow:
+        const uintptr_t padding = (alignment - (x & (alignment - 1))) & (alignment - 1);
         const size_t aligned_offset = sizeof(alignment_marker_t) + padding;
         void* const aligned_storage = (char *)base_storage + aligned_offset;
         BOOST_ASSERT((char *) aligned_storage + holder_size <= (char *)base_storage + base_allocation);


### PR DESCRIPTION
Fixed a crash on Solaris 11 with gcc 7.3.1 when a binding uses make_constructor () like:
```cpp
def_class<integer_type> ("numeric")
  .def("__init__", make_constructor (&integer::from_tuple),
       "Initialize from a tuple")
```

The crash is caused from pull request #360. It works fine when I revert the changes of this pull request.

In make_constructor.hpp, the address of the structure pointer_holder should be aligned with the correct alignment value instead of the default value 1. Otherwise, it crashes in the placement new operator:
```cpp
(new (memory) holder(std::move(x)))
```

Fix the calculation of the padding required to align the start of a data structure. The padding cannot be equal to the alignment. It is always smaller than the alignment. The formula is taken from wikipedia which is equivalent to @aristk 's suggestion at #384:
https://en.wikipedia.org/wiki/Data_structure_alignment
