### PR TITLE
Pass alignment to holder::allocate

### DIFF
--- a/include/boost/python/make_constructor.hpp
+++ b/include/boost/python/make_constructor.hpp
@@ -61,8 +61,8 @@ namespace detail
           typedef objects::pointer_holder<Ptr,value_type> holder;
           typedef objects::instance<holder> instance_t;
 
-          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage),
-	                                  sizeof(holder), alignof(holder));
+          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage), sizeof(holder),
+	                                  boost::python::detail::alignment_of<holder>::value);
           try {
 #if defined(BOOST_NO_CXX11_SMART_PTR)
               (new (memory) holder(x))->install(this->m_self);

--- a/include/boost/python/make_constructor.hpp
+++ b/include/boost/python/make_constructor.hpp
@@ -61,7 +61,8 @@ namespace detail
           typedef objects::pointer_holder<Ptr,value_type> holder;
           typedef objects::instance<holder> instance_t;
 
-          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage), sizeof(holder));
+          void* memory = holder::allocate(this->m_self, offsetof(instance_t, storage),
+	                                  sizeof(holder), alignof(holder));
           try {
 #if defined(BOOST_NO_CXX11_SMART_PTR)
               (new (memory) holder(x))->install(this->m_self);


### PR DESCRIPTION
aca3c8 added an alignment argument to holder::allocate which defaults to 1.  However, make_constructor.hpp uses this function to create storage for a pointer and was never changed to pass an alignment, so it uses the too-permissive default.

This causes unaligned pointers to be created on most architectures (although the x86 family tolerates it).  This can be detected as a failure by running projects under Clang ubsan.