### PR TITLE
Normalize static/dynamic link macros and avoid redefinition warnings

### DIFF
--- a/include/boost/python/detail/config.hpp
+++ b/include/boost/python/detail/config.hpp
@@ -57,9 +57,15 @@
  ****************************************************************************/
 
 // backwards compatibility:
-#ifdef BOOST_PYTHON_STATIC_LIB
-#  define BOOST_PYTHON_STATIC_LINK
-# elif !defined(BOOST_PYTHON_DYNAMIC_LIB)
+#if defined(BOOST_PYTHON_STATIC_LINK) && !defined(BOOST_PYTHON_STATIC_LIB)
+#  define BOOST_PYTHON_STATIC_LIB
+#endif
+
+#if defined(BOOST_PYTHON_DYNAMIC_LINK) && !defined(BOOST_PYTHON_DYNAMIC_LIB)
+#  define BOOST_PYTHON_DYNAMIC_LIB
+#endif
+
+#if !defined(BOOST_PYTHON_STATIC_LIB) && !defined(BOOST_PYTHON_DYNAMIC_LIB)
 #  define BOOST_PYTHON_DYNAMIC_LIB
 #endif
 


### PR DESCRIPTION
The static/dynamic config macro logic had two issues; first, it used unconventional macro names (BOOST_PYTHON_STATIC_LIB and BOOST_PYTHON_DYNAMIC_LIB instead of BOOST_PYTHON_STATIC_LINK and BOOST_PYTHON_DYNAMIC_LINK as everything else); second, when both BOOST_PYTHON_STATIC_LINK and BOOST_PYTHON_STATIC_LIB were defined, it caused a macro redefinition warning.

This change fixes both.