### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -14,15 +14,11 @@ constant boost_dependencies :
     /boost/detail//boost_detail
     /boost/foreach//boost_foreach
     /boost/function//boost_function
-    /boost/graph//boost_graph
-    /boost/integer//boost_integer
     /boost/iterator//boost_iterator
     /boost/lexical_cast//boost_lexical_cast
     /boost/mpl//boost_mpl
     /boost/numeric_conversion//boost_numeric_conversion
     /boost/preprocessor//boost_preprocessor
-    /boost/property_map//boost_property_map
-    /boost/smart_ptr//boost_smart_ptr
     /boost/static_assert//boost_static_assert
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/python

--- a/build.jam
+++ b/build.jam
@@ -5,29 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/align//boost_align
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/conversion//boost_conversion
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/foreach//boost_foreach
+    /boost/function//boost_function
+    /boost/graph//boost_graph
+    /boost/integer//boost_integer
+    /boost/iterator//boost_iterator
+    /boost/lexical_cast//boost_lexical_cast
+    /boost/mpl//boost_mpl
+    /boost/numeric_conversion//boost_numeric_conversion
+    /boost/preprocessor//boost_preprocessor
+    /boost/property_map//boost_property_map
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/tuple//boost_tuple
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/python
     : common-requirements
-        <library>/boost/align//boost_align
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/conversion//boost_conversion
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/foreach//boost_foreach
-        <library>/boost/function//boost_function
-        <library>/boost/graph//boost_graph
-        <library>/boost/integer//boost_integer
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/lexical_cast//boost_lexical_cast
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/numeric_conversion//boost_numeric_conversion
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/property_map//boost_property_map
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/tuple//boost_tuple
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
@@ -40,3 +42,4 @@ explicit
 call-if : boost-library python
     : install boost_python boost_numpy
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,42 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/python
+    : common-requirements
+        <source>/boost/align//boost_align
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/conversion//boost_conversion
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/foreach//boost_foreach
+        <source>/boost/function//boost_function
+        <source>/boost/graph//boost_graph
+        <source>/boost/integer//boost_integer
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/lexical_cast//boost_lexical_cast
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/numeric_conversion//boost_numeric_conversion
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/property_map//boost_property_map
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/tuple//boost_tuple
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_python : build//boost_python ]
+    [ alias boost_numpy : build//boost_numpy ]
+    [ alias all : boost_python boost_numpy test ]
+    ;
+
+call-if : boost-library python
+    : install boost_python boost_numpy
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,27 +7,27 @@ import project ;
 
 project /boost/python
     : common-requirements
-        <source>/boost/align//boost_align
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/conversion//boost_conversion
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/foreach//boost_foreach
-        <source>/boost/function//boost_function
-        <source>/boost/graph//boost_graph
-        <source>/boost/integer//boost_integer
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/lexical_cast//boost_lexical_cast
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/numeric_conversion//boost_numeric_conversion
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/property_map//boost_property_map
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/tuple//boost_tuple
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/align//boost_align
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/conversion//boost_conversion
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/foreach//boost_foreach
+        <library>/boost/function//boost_function
+        <library>/boost/graph//boost_graph
+        <library>/boost/integer//boost_integer
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/lexical_cast//boost_lexical_cast
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/numeric_conversion//boost_numeric_conversion
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/property_map//boost_property_map
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/tuple//boost_tuple
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/python
     : common-requirements

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -32,6 +32,7 @@ else
 
 project
   : source-location ../src
+  : common-requirements <library>$(boost_dependencies)
   ;
 
 rule cond ( test ? : yes * : no * ) { if $(test) { return $(yes) ; } else { return $(no) ; } }

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -113,6 +113,7 @@ lib boost_python
     :   # usage requirements
         <link>static:<define>BOOST_PYTHON_STATIC_LIB
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+        <define>BOOST_PYTHON_NO_LIB
     ;
 
 }
@@ -153,6 +154,7 @@ lib boost_numpy
     :   # usage requirements
         <link>static:<define>BOOST_NUMPY_STATIC_LIB
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+        <define>BOOST_NUMPY_NO_LIB
     ;
 
 }

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -104,6 +104,7 @@ lib boost_python
         <dependency>config-warning
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
         -<tag>@%boostcpp.tag
+        -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
         <tag>@tag
         <conditional>@python.require-py
 
@@ -143,6 +144,7 @@ lib boost_numpy
         <library>boost_python
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
         -<tag>@%boostcpp.tag
+        -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
         <tag>@tag
         <conditional>@python.require-py
 

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -30,9 +30,17 @@ else
         ;
 }
 
+constant boost_dependencies_private :
+    /boost/graph//boost_graph
+    /boost/integer//boost_integer
+    /boost/property_map//boost_property_map
+    /boost/smart_ptr//boost_smart_ptr
+    ;
+
 project
   : source-location ../src
   : common-requirements <library>$(boost_dependencies)
+  : requirements <library>$(boost_dependencies_private)
   ;
 
 rule cond ( test ? : yes * : no * ) { if $(test) { return $(yes) ; } else { return $(no) ; } }

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -30,13 +30,24 @@ else
         ;
 }
 
-project boost/python
+project
   : source-location ../src
   ;
 
 rule cond ( test ? : yes * : no * ) { if $(test) { return $(yes) ; } else { return $(no) ; } }
 rule unless ( test ? : yes * : no * ) { if ! $(test) { return $(yes) ; } else { return $(no) ; } }
 local rule eq ( a : b ) { if $(a) = $(b) { return 1 ; } }
+
+rule tag ( name : type ? : property-set )
+{
+    if python-tag in [ RULENAMES $(__name__) ]
+    {
+        return [  $(__name__).python-tag $(name) : $(type) : $(property-set) ] ;
+    }
+}
+
+if [ python.configured ]
+{
 
 lib boost_python
     : # sources
@@ -92,8 +103,8 @@ lib boost_python
         [ unless [ python.configured ] : <build>no ]
         <dependency>config-warning
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
-        -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
-        <tag>@python-tag
+        -<tag>@%boostcpp.tag
+        <tag>@tag
         <conditional>@python.require-py
 
     :   # default build
@@ -102,6 +113,17 @@ lib boost_python
         <link>static:<define>BOOST_PYTHON_STATIC_LIB
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
     ;
+
+}
+else
+{
+
+alias boost_python : config-warning ;
+
+}
+
+if [ python.configured ] && [ python.numpy ]
+{
 
 numpy-include = [ python.numpy-include ] ;
 lib boost_numpy
@@ -120,8 +142,8 @@ lib boost_numpy
         <library>/python//numpy
         <library>boost_python
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
-        -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
-        <tag>@python-tag
+        -<tag>@%boostcpp.tag
+        <tag>@tag
         <conditional>@python.require-py
 
     :   # default build
@@ -131,37 +153,10 @@ lib boost_numpy
         <python-debugging>on:<define>BOOST_DEBUG_PYTHON
     ;
 
-# boost-install creates `stage` and `install` targets
-#
-# `stage` stages (builds and copies into `stage/lib`) the given libraries
-#   `boost_python` and `boost_numpy` and their dependencies and is similar
-#   to issuing `b2 --with-python stage` from top level
-#
-# `install` installs the two libraries and their dependencies and is similar
-#   to issuing `b2 --with-python install` from top level
-
-if [ python.configured ]
-{
-    if [ python.numpy ]
-    {
-        boost-install boost_python boost_numpy ;
-    }
-    else
-    {
-        boost-install boost_python ;
-    }
 }
 else
 {
 
-# When Python isn't configured, the above `boost-install` is not executed,
-# so we create empty `stage` and `install` targets that do nothing but issue
-# a warning message unless `--without-python` is given
-
-alias stage : config-warning ;
-explicit stage ;
-
-alias install : config-warning ;
-explicit install ;
+alias boost_numpy : config-warning ;
 
 }

--- a/example/README.md
+++ b/example/README.md
@@ -3,7 +3,7 @@
 # Examples
 
 This directory contains various examples using Boost.Python.
-You may compile these using the `bjam` command either in this directory
+You may compile these using the `b2` command either in this directory
 or in any of the subdirectories.
 You may need to adjust the paths in the Jamroot file if Boost.Python
 is not installed in a default location.

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -30,7 +30,7 @@ rule py-run ( sources * : input-file ? )
       : $(input-file)
       : #requirements
         <define>BOOST_PYTHON_SUPPRESS_REGISTRY_INITIALIZATION
- 
+
     ] ;
 }
 
@@ -54,6 +54,18 @@ rule require-windows ( properties * )
 
 if [ python.configured ]
 {
+alias base_deps : usage-requirements
+    <library>/boost/align//boost_align
+    <library>/boost/assert//boost_assert
+    <library>/boost/config//boost_config
+    <library>/boost/core//boost_core
+    <library>/boost/detail//boost_detail
+    <library>/boost/function//boost_function
+    <library>/boost/mpl//boost_mpl
+    <library>/boost/preprocessor//boost_preprocessor
+    <library>/boost/static_assert//boost_static_assert
+    <library>/boost/type_traits//boost_type_traits
+    ;
 test-suite python
   :
 
@@ -99,8 +111,8 @@ bpl-test crossmod_exception
 [ bpl-test andreas_beyer ]
 [ bpl-test wrapper_held_type ]
 
-[ bpl-test polymorphism2_auto_ptr 
-  : polymorphism2_auto_ptr.py polymorphism2.py polymorphism2_auto_ptr.cpp 
+[ bpl-test polymorphism2_auto_ptr
+  : polymorphism2_auto_ptr.py polymorphism2.py polymorphism2_auto_ptr.cpp
   : [ requires auto_ptr ]
 ]
 
@@ -121,7 +133,7 @@ bpl-test crossmod_exception
 [ bpl-test try : newtest.py m1.cpp m2.cpp ]
 [ bpl-test const_argument ]
 [ bpl-test keywords : keywords.cpp keywords_test.py ]
-   
+
 
 [ python-extension builtin_converters_ext : builtin_converters.cpp /boost/python//boost_python ]
 [ bpl-test builtin_converters : test_builtin_converters.py builtin_converters_ext ]
@@ -194,13 +206,13 @@ bpl-test crossmod_opaque
     # Whenever the cause for the failure of the polymorphism test is found
     # and fixed, this should be retested.
     <toolset>hp_cxx:<build>no ]
-      
+
 [ python-extension map_indexing_suite_ext
     : map_indexing_suite.cpp int_map_indexing_suite.cpp a_map_indexing_suite.cpp
     /boost/python//boost_python ]
-[ bpl-test  
+[ bpl-test
     map_indexing_suite : map_indexing_suite.py map_indexing_suite_ext ]
-      
+
 [ run import_.cpp /boost/python//boost_python $(PY) : : import_.py ]
 
 # if $(TEST_BIENSTMAN_NON_BUGS)
@@ -214,28 +226,29 @@ bpl-test crossmod_opaque
 
 # --- unit tests of library components ---
 
-[ compile indirect_traits_test.cpp ]
-[ run destroy_test.cpp ]
+[ compile indirect_traits_test.cpp : <use>base_deps ]
+[ run destroy_test.cpp : : : <use>base_deps ]
 [ py-run pointer_type_id_test.cpp ]
 [ py-run bases.cpp ]
-[ run if_else.cpp ]
+[ run if_else.cpp : : : <use>base_deps ]
 [ py-run pointee.cpp ]
-[ run result.cpp ]
+[ run result.cpp : : : <use>base_deps ]
 
-[ compile string_literal.cpp ]
+[ compile string_literal.cpp : <use>base_deps ]
 [ py-compile borrowed.cpp ]
 [ py-compile object_manager.cpp ]
 [ py-compile copy_ctor_mutates_rhs.cpp ]
 
 [ py-run upcast.cpp ]
-  
+
 [ py-compile select_holder.cpp ]
-  
-[ run select_from_python_test.cpp ../src/converter/type_id.cpp 
-  :   
+
+[ run select_from_python_test.cpp ../src/converter/type_id.cpp
+  :
   :
   : <define>BOOST_PYTHON_STATIC_LIB
     <use>$(PY)
+    <use>base_deps
 
 ]
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -2,14 +2,16 @@
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+
 import python ;
 import os ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 lib socket ;
 
-use-project /boost/python : ../build ;
-project /boost/python/test 
+project
   : requirements
     <toolset>gcc:<cxxflags>-Wextra
     <target-os>qnxnto:<library>socket


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.