### PR TITLE
Fix up Python2 regressions in PR 417

### DIFF
--- a/src/object/function.cpp
+++ b/src/object/function.cpp
@@ -586,6 +586,13 @@ BOOST_PYTHON_DECL void add_to_namespace(
 
 BOOST_PYTHON_DECL object const& add_doc(object const& attribute, char const* doc)
 {
+#if PY_VERSION_HEX >= 0x03000000
+    if (PyInstanceMethod_Check(attribute.ptr())) {
+#else
+    if (PyMethod_Check(attribute.ptr())) {
+#endif
+        return attribute;
+    }
     return function::add_doc(attribute, doc);
 }
 


### PR DESCRIPTION
boostorg/python#417 introduced some regressions with Python2. To whit:

- `add_property()` attempts to add docstrings to functions passed to it. `test.properties` [binds an existing instance method again as a getter](https://github.com/boostorg/python/blob/c76d67ef3fe81eb4177cfcaa2d6486395e3aed75/test/properties.cpp#L97), which works fine on Python3, where `klass.member` returns the underlying function object. On Python2, however, this returned an unbound `instancemethod` with an immutable `__doc__` attribute. Work around this by skipping docstring generation on `PyMethod` objects.
- `test.nested` exercises the `__qualname__` attribute, which didn't exist before Python 3.3. Use doctest option flags to make examples conditional on the Python version.