### PR TITLE
docs: modify logo variable

### DIFF
--- a/doc/numpy/_templates/layout.html
+++ b/doc/numpy/_templates/layout.html
@@ -90,7 +90,7 @@
       <tr>
         <td valign="top" width="300">
           <h3><a href="{{ pathto('index') }}"><img 
-          alt="C++ Boost" src="{{ pathto('_static/' + logo, 1) }}" border="0"></a></h3>
+          alt="C++ Boost" src="{{ pathto('_static/' + 'bpl.png', 1) }}" border="0"></a></h3>
         </td>
 
         <td >


### PR DESCRIPTION
When building the docs with Sphinx 8.1.3 there is an error about 'logo'.

Where is the variable originally defined?

The modification in this PR seems to solve the problem.