### PR TITLE
Prevent potential data loss in numpy's dtype::get_itemsize().

### DIFF
--- a/include/boost/python/numpy/dtype.hpp
+++ b/include/boost/python/numpy/dtype.hpp
@@ -47,7 +47,7 @@ public:
   template <typename T> static dtype get_builtin();
 
   /// @brief Return the size of the data type in bytes.
-  int get_itemsize() const;
+  Py_ssize_t get_itemsize() const;
 
   /**
    *  @brief Compare two dtypes for equivalence.

--- a/src/numpy/dtype.cpp
+++ b/src/numpy/dtype.cpp
@@ -98,7 +98,7 @@ python::detail::new_reference dtype::convert(object const & arg, bool align)
   return python::detail::new_reference(reinterpret_cast<PyObject*>(obj));
 }
 
-int dtype::get_itemsize() const {
+Py_ssize_t dtype::get_itemsize() const {
 #if NPY_ABI_VERSION < 0x02000000
   return reinterpret_cast<PyArray_Descr*>(ptr())->elsize;
 #else


### PR DESCRIPTION
The numpy 2.0 migration guide states [https://numpy.org/devdocs/numpy_2_0_migration_guide.html]:

"PyDataType_ELSIZE and PyDataType_SET_ELSIZE (note that the result is now npy_intp and not int)."

Even though it is rather unlikely to have have elements larger than 2GB each, prevent potential numerical overflows, which could occur when casting ssize_t to int on 64-bit systems.