### PR TITLE
Replace Boost::foreach dependency with range-based for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ target_link_libraries(${_boost_python}
     Boost::conversion
     Boost::core
     Boost::detail
-    Boost::foreach
     Boost::function
     Boost::iterator
     Boost::lexical_cast

--- a/build.jam
+++ b/build.jam
@@ -12,7 +12,6 @@ constant boost_dependencies :
     /boost/conversion//boost_conversion
     /boost/core//boost_core
     /boost/detail//boost_detail
-    /boost/foreach//boost_foreach
     /boost/function//boost_function
     /boost/iterator//boost_iterator
     /boost/lexical_cast//boost_lexical_cast

--- a/include/boost/python/suite/indexing/container_utils.hpp
+++ b/include/boost/python/suite/indexing/container_utils.hpp
@@ -8,26 +8,21 @@
 # define PY_CONTAINER_UTILS_JDG20038_HPP
 
 # include <utility>
-# include <boost/foreach.hpp>
 # include <boost/python/object.hpp>
 # include <boost/python/handle.hpp>
 # include <boost/python/extract.hpp>
 # include <boost/python/stl_iterator.hpp>
 
 namespace boost { namespace python { namespace container_utils {
-        
+
     template <typename Container>
     void
     extend_container(Container& container, object l)
     {
         typedef typename Container::value_type data_type;
-        
+
         //  l must be iterable
-        BOOST_FOREACH(object elem,
-            std::make_pair(
-              boost::python::stl_input_iterator<object>(l),
-              boost::python::stl_input_iterator<object>()
-              ))
+        for (object elem: l)
         {
             extract<data_type const&> x(elem);
             //  try if elem is an exact data_type type
@@ -49,7 +44,7 @@ namespace boost { namespace python { namespace container_utils {
                     throw_error_already_set();
                 }
             }
-        }          
+        }
     }
 
 }}} // namespace boost::python::container_utils


### PR DESCRIPTION
While the library is still marked as c++03 compatible I wonder if the time has come to follow the rest of the boost libraries and raise it up to c++11.