### PR TITLE
refactor: use BOOST_NOEXCEPT_OR_NOTHROW

### DIFF
--- a/include/boost/python/instance_holder.hpp
+++ b/include/boost/python/instance_holder.hpp
@@ -7,6 +7,7 @@
 
 # include <boost/python/detail/prefix.hpp>
 
+# include <boost/config.hpp>
 # include <boost/noncopyable.hpp>
 # include <boost/python/type_id.hpp>
 # include <cstddef>
@@ -31,7 +32,7 @@ struct BOOST_PYTHON_DECL instance_holder : private noncopyable
     // that always holds the Python object.
     virtual void* holds(type_info, bool null_ptr_only) = 0;
 
-    void install(PyObject* inst) throw();
+    void install(PyObject* inst) BOOST_NOEXCEPT_OR_NOTHROW;
 
     // These functions should probably be located elsewhere.
     
@@ -42,7 +43,7 @@ struct BOOST_PYTHON_DECL instance_holder : private noncopyable
 
     // Deallocate storage from the heap if it was not carved out of
     // the given Python object by allocate(), above.
-    static void deallocate(PyObject*, void* storage) throw();
+    static void deallocate(PyObject*, void* storage) BOOST_NOEXCEPT_OR_NOTHROW;
  private:
     instance_holder* m_next;
 };

--- a/src/object/class.cpp
+++ b/src/object/class.cpp
@@ -4,6 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/python/detail/prefix.hpp>
+#include <boost/config.hpp>
 #include <boost/mpl/lambda.hpp> // #including this first is an intel6 workaround
 #include <boost/cstdint.hpp>
 
@@ -302,7 +303,7 @@ static PyTypeObject class_metatype_object = {
 
 // Install the instance data for a C++ object into a Python instance
 // object.
-void instance_holder::install(PyObject* self) throw()
+void instance_holder::install(PyObject* self) BOOST_NOEXCEPT_OR_NOTHROW
 {
     assert(PyType_IsSubtype(Py_TYPE(Py_TYPE(self)), &class_metatype_object));
     m_next = ((objects::instance<>*)self)->objects;
@@ -779,7 +780,7 @@ void* instance_holder::allocate(PyObject* self_, std::size_t holder_offset, std:
     }
 }
 
-void instance_holder::deallocate(PyObject* self_, void* storage) throw()
+void instance_holder::deallocate(PyObject* self_, void* storage) BOOST_NOEXCEPT_OR_NOTHROW
 {
     assert(PyType_IsSubtype(Py_TYPE(Py_TYPE(self_)), &class_metatype_object));
     objects::instance<>* self = (objects::instance<>*)self_;

--- a/test/module_tail.cpp
+++ b/test/module_tail.cpp
@@ -31,15 +31,17 @@ extern "C" void (*old_translator)(unsigned, EXCEPTION_POINTERS*)
 #include <exception>
 #include <boost/python/extract.hpp>
 #include <boost/python/str.hpp>
+#include <boost/config.hpp>
+
 struct test_failure : std::exception
 {
     test_failure(char const* expr, char const* /*function*/, char const* file, unsigned line)
       : msg(file + boost::python::str(":%s:") % line + ": Boost.Python assertion failure: " + expr)
     {}
 
-    ~test_failure() throw() {}
+    ~test_failure() BOOST_NOEXCEPT_OR_NOTHROW {}
     
-    char const* what() const throw()
+    char const* what() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return boost::python::extract<char const*>(msg)();
     }


### PR DESCRIPTION
specifier `throw()` is deprecated since C++11