### PR TITLE
chore: remove meaningless comparison

### DIFF
--- a/src/object/function.cpp
+++ b/src/object/function.cpp
@@ -161,7 +161,6 @@ PyObject* function::call(PyObject* args, PyObject* keywords) const
                     else
                     {
                         // build a new arg tuple, will adjust its size later
-                        assert(max_arity <= static_cast<std::size_t>(ssize_t_max));
                         inner_args = handle<>(
                             PyTuple_New(static_cast<ssize_t>(max_arity)));
 


### PR DESCRIPTION
```console
$ faber --builddir=build cxx.name=clang++
…
clangxx.compile src.object/function.o
./src/object/function.cpp:164:42: warning: result of comparison of constant 9223372036854775807 with expression of type 'unsigned int' >
  164 |                         assert(max_arity <= static_cast<std::size_t>(ssize_t_max));
      |                                ~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:100:27: note: expanded from macro 'assert'
  100 |      (static_cast <bool> (expr)                                         \
      |                           ^~~~
1 warning generated.
…」
```