### PR TITLE
Use Py_REFCNT instead of ->ob_refcnt

### DIFF
--- a/src/converter/from_python.cpp
+++ b/src/converter/from_python.cpp
@@ -222,7 +222,7 @@ namespace
       , char const* ref_type)
   {
       handle<> holder(source);
-      if (source->ob_refcnt <= 1)
+      if (Py_REFCNT(source) <= 1)
       {
           handle<> msg(
 #if PY_VERSION_HEX >= 0x3000000


### PR DESCRIPTION
Py_REFCNT was stabilized in 3.9, uses this official API instead of the `ob_refcnt` field that doesn't exist in the free-threaded build of 3.13.