### PR TITLE
Fix warning C4456: declaration of 'storage' hides previous local declaration

### DIFF
--- a/include/boost/python/converter/shared_ptr_from_python.hpp
+++ b/include/boost/python/converter/shared_ptr_from_python.hpp
@@ -49,16 +49,9 @@ struct shared_ptr_from_python
       new (storage) SP<T>();
     else
     {
-      void *const storage = ((converter::rvalue_from_python_storage<SP<T> >*)data)->storage.bytes;
-      // Deal with the "None" case.
-      if (data->convertible == source)
-        new (storage) SP<T>();
-      else
-      {
-        SP<void> hold_convertible_ref_count((void*)0, shared_ptr_deleter(handle<>(borrowed(source))) );
-        // use aliasing constructor
-        new (storage) SP<T>(hold_convertible_ref_count, static_cast<T*>(data->convertible));
-      }
+      SP<void> hold_convertible_ref_count((void*)0, shared_ptr_deleter(handle<>(borrowed(source))) );
+      // use aliasing constructor
+      new (storage) SP<T>(hold_convertible_ref_count, static_cast<T*>(data->convertible));
     }
     data->convertible = storage;
   }


### PR DESCRIPTION
This is a copy-paste issue introduced in https://github.com/boostorg/python/commit/aca3c80c4f80dd3d52219e1ee299e08bb980bcfd