### PR TITLE
:bug: Fix broken link to Jamroot in example docs

### DIFF
--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -117,7 +117,7 @@ platforms. The complete list of Bjam executables can be found
 [h2 Let's Jam!]
 __jam__
 
-[@../../../../example/tutorial/Jamroot Here] is our minimalist Jamroot
+[@../example/Jamroot Here] is our minimalist Jamroot
 file. Simply copy the file and tweak [^use-project boost] to where your
 boost root directory is and you're OK.
 


### PR DESCRIPTION
Fixes #489 

I have verified locally that the path is correct. Does this need some other verification?