### PR TITLE
Downgrade `run-vcpkg` to avoid Windows build regression.

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -42,7 +42,7 @@ jobs:
     - name: build
       shell: cmd
       run: |
-        faber --builddir=build cxx.name=msvc --with-boost-include=${{ runner.workspace }}\vcpkg\installed\x64-windows\include -j4
+        faber --builddir=build cxx.name=msvc --log=commands --log=output --with-boost-include=${{ runner.workspace }}\vcpkg\installed\x64-windows\include -j4
     - name: test
       shell: cmd
       run: |


### PR DESCRIPTION
@e-kwsm , I need to revert your upgrade of the `run-vcpkg` package in the Windows CI pipeline. I'm not exactly sure what was broken, but it generated an error, and ultimately failed the build.

As this is now making all builds pass, I'd suggest that you rebase all your other PRs so we can merge them once the CI builds have succeeded.