### PR TITLE
Include missing header boost/type_traits/is_unsigned.hpp

### DIFF
--- a/include/boost/python/numpy/dtype.hpp
+++ b/include/boost/python/numpy/dtype.hpp
@@ -17,6 +17,7 @@
 #include <boost/python/numpy/numpy_object_mgr_traits.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <boost/python/detail/type_traits.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
 
 namespace boost { namespace python { namespace numpy {
 


### PR DESCRIPTION
During the Debian Packaging of new version it was found that this header is missing during the build with GCC-15.