### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,6 @@ target_link_libraries(${_boost_python}
     Boost::numeric_conversion
     Boost::preprocessor
     Boost::smart_ptr
-    Boost::static_assert
     Boost::tuple
     Boost::type_traits
     Boost::utility

--- a/build.jam
+++ b/build.jam
@@ -19,7 +19,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/numeric_conversion//boost_numeric_conversion
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -63,7 +63,6 @@ alias base_deps : usage-requirements
     <library>/boost/function//boost_function
     <library>/boost/mpl//boost_mpl
     <library>/boost/preprocessor//boost_preprocessor
-    <library>/boost/static_assert//boost_static_assert
     <library>/boost/type_traits//boost_type_traits
     ;
 test-suite python


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.