### PR TITLE
refactor: use PyUnicode_AsUTF8 with Python 3.14+

### DIFF
--- a/src/converter/builtin_converters.cpp
+++ b/src/converter/builtin_converters.cpp
@@ -40,22 +40,18 @@ namespace
 
   // An lvalue conversion function which extracts a char const* from a
   // Python String.
+  void* convert_to_cstring(PyObject* obj)
+  {
 #if PY_VERSION_HEX < 0x03000000
-  void* convert_to_cstring(PyObject* obj)
-  {
       return PyString_Check(obj) ? PyString_AsString(obj) : 0;
-  }
 #elif PY_VERSION_HEX < 0x03070000
-  void* convert_to_cstring(PyObject* obj)
-  {
       return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
-  }
-#else
-  void* convert_to_cstring(PyObject* obj)
-  {
+#elif PY_VERSION_HEX < 0x030E0000
       return PyUnicode_Check(obj) ? const_cast<void*>(reinterpret_cast<const void*>(_PyUnicode_AsString(obj))) : 0;
-  }
+#else
+      return PyUnicode_Check(obj) ? const_cast<void*>(reinterpret_cast<const void*>(PyUnicode_AsUTF8(obj))) : 0;
 #endif
+  }
 
   // Given a target type and a SlotPolicy describing how to perform a
   // given conversion, registers from_python converters which use the


### PR DESCRIPTION
_PyUnicode_AsString is deprecated since Python 3.14

https://docs.python.org/3.14/deprecations/index.html#id2

fix #512