### PR TITLE
Docs: adjust template to support Sphinx 9

### DIFF
--- a/doc/numpy/_templates/layout.html
+++ b/doc/numpy/_templates/layout.html
@@ -47,7 +47,7 @@
       };
     </script>
     {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto(scriptfile.filename if scriptfile.filename is defined else scriptfile, 1) }}"></script>
     {%- endfor %}
     <script data-url_root="{{ pathto('', 1) }}" id="documentation_options" src="{{ pathto('', 1) }}_static/documentation_options.js"></script>
     <script src="{{ pathto('', 1) }}_static/searchtools.js"></script>


### PR DESCRIPTION
The current docs will not yet build on Sphinx 9.

This PR solves this error:

/opt/venvboostdocs/lib/python3.12/site-packages/sphinx/util/osutil.py:51: RemovedInSphinx90Warning: The str interface for _JavaScript objects is deprecated. Use js.filename instead.
t2 = to.split('#')[0].split(SEP)